### PR TITLE
moved event handlers before calling start to fix not receiving onMess…

### DIFF
--- a/packages/audiolib/src/nodes/recorder/Recorder.ts
+++ b/packages/audiolib/src/nodes/recorder/Recorder.ts
@@ -115,7 +115,6 @@ export class Recorder implements LibNode {
     this.#state = AudioRecorderState.ARMED;
     console.info('Recorder state: ARMED');
 
-    // ! record:armed doesnt seem to send a reliable message
     this.sendMessage('record:armed', {
       threshold: this.#config!.startThreshold,
       destination: this.#destination,


### PR DESCRIPTION
### **User description**
…age armed


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed event handler timing issue in RecordButton

- Moved onMessage listeners before recorder.start() call

- Added proper recorder cleanup and state mapping

- Removed unreliable message comment from Recorder


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Create Recorder"] --> B["Setup Event Handlers"]
  B --> C["Call recorder.start()"]
  C --> D["Receive Armed State"]
  D --> E["Update Button State"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RecordButton.ts</strong><dd><code>Fix event handler timing and state management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/audio-components/src/elements/Sampler/components/RecordButton.ts

<ul><li>Moved <code>onMessage</code> event handler setup before <code>recorder.start()</code> call<br> <li> Added proper state mapping from recorder states to button states<br> <li> Implemented recorder cleanup by setting <code>currentRecorder = null</code><br> <li> Create new recorder instance for each recording session</ul>


</details>


  </td>
  <td><a href="https://github.com/KristinnRoach/sampler-monorepo/pull/99/files#diff-4b93df7b792c22381aff299c8ae003b66de6778d627d1fd9aacfece362555daa">+30/-13</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Recorder.ts</strong><dd><code>Remove outdated comment about armed message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/audiolib/src/nodes/recorder/Recorder.ts

- Removed comment about unreliable `record:armed` message


</details>


  </td>
  <td><a href="https://github.com/KristinnRoach/sampler-monorepo/pull/99/files#diff-7d8564399492c74435dc5fe7b7911e09a213bbfa6992a03536e4d6bfd8fced15">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the recording logic to ensure a new audio recorder is created for each session and enhanced the mapping of recorder states to button states for clearer status updates.
* **Style**
  * Removed an outdated comment to clean up the code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->