### PR TITLE
filter-env ok, but should add amount control and maybe allow below as…

### DIFF
--- a/packages/audio-components/src/elements/controls/envelope/EnvelopeSVG.ts
+++ b/packages/audio-components/src/elements/controls/envelope/EnvelopeSVG.ts
@@ -315,7 +315,7 @@ export const EnvelopeSVG = (
 
       const normalizedValue = absoluteValueToNormalized(
         point.value,
-        envelopeInfo.valueRange,
+        envelopeInfo.envPointValueRange,
         'linear'
         // envelopeType === 'filter-env' ? 'logarithmic' : 'linear'
       );
@@ -463,7 +463,7 @@ export const EnvelopeSVG = (
         envelopeInfo.fullDuration,
         SVG_WIDTH - 2 * CIRCLE_PADDING,
         SVG_HEIGHT - 2 * CIRCLE_PADDING - TOP_BTNS_PADDING,
-        envelopeInfo.valueRange,
+        envelopeInfo.envPointValueRange,
         'linear',
         // envelopeType === 'filter-env' ? 'logarithmic' : 'linear',
         CIRCLE_PADDING,
@@ -807,7 +807,7 @@ export const EnvelopeSVG = (
       let value = screenYToAbsoluteValue(
         coords.y - rect.top - CIRCLE_PADDING - TOP_BTNS_PADDING,
         rect.height - 2 * CIRCLE_PADDING - TOP_BTNS_PADDING,
-        envelopeInfo.valueRange
+        envelopeInfo.envPointValueRange
       );
 
       // Apply snapping in normalized space
@@ -815,7 +815,7 @@ export const EnvelopeSVG = (
         value,
         snapToValues.y,
         snapThreshold,
-        envelopeInfo.valueRange
+        envelopeInfo.envPointValueRange
       );
 
       // Handle fixed start/end times
@@ -829,15 +829,15 @@ export const EnvelopeSVG = (
 
       // console.warn('value before log:', value);
       // if (envelopeType === 'filter-env')
-      //   value = linearToLogarithmic(value, envelopeInfo.valueRange);
+      //   value = linearToLogarithmic(value, envelopeInfo.envPointValueRange);
 
       // console.warn('value after log:', value);
       // const normalizedValue = absoluteValueToNormalized(
       //   value,
-      //   envelopeInfo.valueRange,
+      //   envelopeInfo.envPointValueRange,
       //   envelopeType === 'filter-env' ? 'logarithmic' : 'linear'
       // );
-      // console.warn('envelopeInfo.valueRange', envelopeInfo.valueRange);
+      // console.warn('envelopeInfo.envPointValueRange', envelopeInfo.envPointValueRange);
       // console.warn('normalized value:', normalizedValue);
 
       instrument.updateEnvelopePoint(
@@ -890,7 +890,7 @@ export const EnvelopeSVG = (
     let value = screenYToAbsoluteValue(
       coords.y - rect.top - CIRCLE_PADDING - TOP_BTNS_PADDING,
       rect.height - 2 * CIRCLE_PADDING - TOP_BTNS_PADDING,
-      envelopeInfo.valueRange
+      envelopeInfo.envPointValueRange
     );
 
     // Apply snapping for consistency with drag behavior
@@ -898,18 +898,18 @@ export const EnvelopeSVG = (
       value,
       snapToValues.y,
       snapThreshold,
-      envelopeInfo.valueRange
+      envelopeInfo.envPointValueRange
     );
 
     time = applySnapping(time, snapToValues.x, snapThreshold);
 
     // // Convert to logarithmic space for filter envelopes
     // if (envelopeType === 'filter-env') {
-    //   value = linearToLogarithmic(value, envelopeInfo.valueRange);
+    //   value = linearToLogarithmic(value, envelopeInfo.envPointValueRange);
     // }
     // const normalizedValue = absoluteValueToNormalized(
     //   value,
-    //   envelopeInfo.valueRange,
+    //   envelopeInfo.envPointValueRange,
     //   envelopeType === 'filter-env' ? 'logarithmic' : 'linear'
     // );
 
@@ -1059,7 +1059,17 @@ export const EnvelopeSVG = (
       if (envType === 'amp-env') {
         if (msg.enabled && !envelopeInfo.sustainEnabled) {
           momentarySustainForLoop = true;
-          instrument.setEnvelopeSustainPoint(envType, 2); // TODO: Use last-used sustainPoint index!
+
+          // TODO: Use last-used sustainPoint index.
+          // Temp safe solution for now:
+          const env = instrument.getEnvelope(envType);
+          const ptsLen = env.points.length;
+          const sustainIdx =
+            env.sustainPointIndex ??
+            Math.max(1, Math.min(ptsLen - 2, Math.round((ptsLen - 1) / 2)));
+
+          instrument.setEnvelopeSustainPoint(envType, sustainIdx);
+          instrument.setEnvelopeSustainPoint(envType, 2);
           updateControlPoints();
           updateEnvelopePath();
         } else if (!msg.enabled && momentarySustainForLoop) {

--- a/packages/audiolib/src/nodes/instruments/Sample/SampleVoice.ts
+++ b/packages/audiolib/src/nodes/instruments/Sample/SampleVoice.ts
@@ -192,7 +192,7 @@ export class SampleVoice {
 
       const filterEnv = createEnvelope(this.context, 'filter-env', {
         durationSeconds,
-        paramValueRange: [0, 1],
+        envPointValueRange: [0, 1],
         initEnable: false,
       });
 
@@ -503,14 +503,10 @@ export class SampleVoice {
       cancelPrevious?: boolean;
     } = {}
   ) {
-    if (
-      // !(this.state === 'PLAYING') ||
-      this.getParam('playbackRate')?.value === 1 ||
-      !this.#activeMidiNote ||
-      !this.#hpf ||
-      this.#keytrackHPFAmount <= 0
-    )
+    if (!this.#activeMidiNote || !this.#hpf || this.#keytrackHPFAmount <= 0) {
       return;
+    }
+
     const freq = this.#hpf.frequency;
     const { glideTime = 0, cancelPrevious = true } = options || {};
     if (cancelPrevious) {
@@ -537,12 +533,7 @@ export class SampleVoice {
       cancelPrevious?: boolean;
     } = {}
   ) {
-    if (
-      this.getParam('playbackRate')?.value === 1 ||
-      !this.#activeMidiNote ||
-      !this.#lpf ||
-      this.#keytrackLPFAmount <= 0
-    ) {
+    if (!this.#activeMidiNote || !this.#lpf || this.#keytrackLPFAmount <= 0) {
       return;
     }
 
@@ -554,8 +545,6 @@ export class SampleVoice {
 
     const keytrackedHz = this.#lpfHz * playbackRate * this.#keytrackLPFAmount;
     const safeHz = clamp(keytrackedHz, 20, this.context.sampleRate / 2 - 1000);
-
-    console.warn('keytrackedHz', safeHz);
 
     if (glideTime > 0) {
       freq.setTargetAtTime(safeHz, atTime, glideTime);
@@ -1114,7 +1103,7 @@ export class SampleVoice {
     const safeHz = clamp(hz, 20, this.context.sampleRate / 2 - 1000);
     this.#hpfHz = safeHz;
     if (this.#hpf) {
-      this.#setParam('hpf', safeHz, this.now, { glideTime: 0 });
+      this.#setParam('hpf', safeHz, atTime, { glideTime: 0 });
       // this.#hpf.frequency.setValueAtTime(safeHz, this.now);
       const currentRate = this.getParam('playbackRate')?.value ?? 1;
       this.#updateHPFCutoffForPlaybackRate(currentRate, atTime, options);
@@ -1130,7 +1119,7 @@ export class SampleVoice {
     const safeHz = clamp(hz, 20, this.context.sampleRate / 2 - 1000);
     this.#lpfHz = safeHz;
     if (this.#lpf) {
-      this.#setParam('lpf', safeHz, this.now, {
+      this.#setParam('lpf', safeHz, atTime, {
         glideTime: 0,
         cancelPrevious: true,
       });

--- a/packages/audiolib/src/nodes/params/envelopes/EnvelopeData.ts
+++ b/packages/audiolib/src/nodes/params/envelopes/EnvelopeData.ts
@@ -4,7 +4,7 @@ import { EnvelopePoint } from './env-types';
 
 // ===== ENVELOPE DATA - Pure data operations =====
 export class EnvelopeData {
-  #valueRange: [number, number];
+  #pointValueRange: [number, number];
   #durationSeconds: number = 0;
   #hasSharpTransitions = false;
 
@@ -26,7 +26,7 @@ export class EnvelopeData {
     );
 
     this.#durationSeconds = durationSeconds;
-    this.#valueRange = valueRange;
+    this.#pointValueRange = valueRange;
 
     this.#startIdx = 0;
     this.#endIdx = points.length - 1;
@@ -151,7 +151,7 @@ export class EnvelopeData {
   }
 
   interpolateValueAtTime(timeSeconds: number): number {
-    if (this.points.length === 0) return this.#valueRange[0];
+    if (this.points.length === 0) return this.#pointValueRange[0];
     if (this.points.length === 1) return this.points[0].value;
 
     const sorted = [...this.points].sort((a, b) => a.time - b.time);
@@ -242,11 +242,11 @@ export class EnvelopeData {
     return this.#endIdx;
   }
 
-  get valueRange() {
-    return this.#valueRange;
+  get pointValueRange() {
+    return this.#pointValueRange;
   }
 
-  setValueRange = (range: [number, number]) => (this.#valueRange = range);
+  setValueRange = (range: [number, number]) => (this.#pointValueRange = range);
 
   get startTime() {
     return this.points[this.#startIdx]?.time ?? 0;

--- a/packages/audiolib/src/nodes/params/envelopes/createEnvelope.ts
+++ b/packages/audiolib/src/nodes/params/envelopes/createEnvelope.ts
@@ -6,7 +6,7 @@ import type { EnvelopeData } from './EnvelopeData';
 interface EnvelopeOptions {
   durationSeconds?: number;
   points?: EnvelopePoint[];
-  paramValueRange?: [number, number];
+  envPointValueRange?: [number, number];
   initEnable?: boolean;
   sharedData?: EnvelopeData;
   sustainPointIndex?: number | null;
@@ -23,7 +23,7 @@ export function createEnvelope(
     points,
     sustainPointIndex,
     releasePointIndex,
-    paramValueRange,
+    envPointValueRange,
     initEnable,
     sharedData,
   } = options;
@@ -37,7 +37,7 @@ export function createEnvelope(
 
   // Use custom values or defaults
   const finalPoints = points || defaults.points;
-  let finalValueRange = paramValueRange || defaults.paramValueRange;
+  let finalValueRange = envPointValueRange || defaults.envPointValueRange;
   const finalInitEnable =
     initEnable !== undefined ? initEnable : defaults.initEnable;
   const finalSustainIndex =


### PR DESCRIPTION
### **User description**
… well as above current cutoff. pitch-env needs work, but first need to decide whether to use a distinct param instead of playback rate, (or the delay based approach?)


___

### **PR Type**
Enhancement


___

### **Description**
- Rename `valueRange` to `envPointValueRange` for clarity

- Fix filter cutoff parameter timing issues

- Improve loop sustain point calculation logic

- Remove debug console warnings


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["EnvelopeData"] -- "rename property" --> B["envPointValueRange"]
  C["SampleVoice"] -- "fix timing" --> D["Filter Cutoff Params"]
  E["EnvelopeSVG"] -- "improve logic" --> F["Loop Sustain Point"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EnvelopeSVG.ts</strong><dd><code>Update envelope property naming and sustain logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/audio-components/src/elements/controls/envelope/EnvelopeSVG.ts

<ul><li>Replace <code>valueRange</code> with <code>envPointValueRange</code> throughout component<br> <li> Improve loop sustain point calculation with safer fallback logic<br> <li> Update commented code references to use new property name</ul>


</details>


  </td>
  <td><a href="https://github.com/KristinnRoach/sampler-monorepo/pull/141/files#diff-e84de0d715d6a2c457407f6d09eea265757ef8aad3bcbe52d5b4371802b9ab96">+22/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CustomEnvelope.ts</strong><dd><code>Refactor envelope value range property naming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/audiolib/src/nodes/params/envelopes/CustomEnvelope.ts

<ul><li>Rename <code>valueRange</code> property to <code>envPointValueRange</code> throughout class<br> <li> Update method names from <code>#clampToValueRange</code> to <code>#clampToPointValueRange</code><br> <li> Adjust envelope value calculation logic for different envelope types<br> <li> Update default configurations to use new property naming</ul>


</details>


  </td>
  <td><a href="https://github.com/KristinnRoach/sampler-monorepo/pull/141/files#diff-c9c4c4e97c695ef94af6353056b9c188ec50cd128368fbb7371012abd43d8271">+17/-23</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EnvelopeData.ts</strong><dd><code>Rename value range property in envelope data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/audiolib/src/nodes/params/envelopes/EnvelopeData.ts

<ul><li>Rename private field <code>#valueRange</code> to <code>#pointValueRange</code><br> <li> Update getter method from <code>valueRange</code> to <code>pointValueRange</code><br> <li> Maintain backward compatibility with <code>setValueRange</code> method</ul>


</details>


  </td>
  <td><a href="https://github.com/KristinnRoach/sampler-monorepo/pull/141/files#diff-12b54d8a307e195171d9a7385fbe1f9823b3eeb206f56ef0f6d004273eeeeb17">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>createEnvelope.ts</strong><dd><code>Update envelope creation interface naming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/audiolib/src/nodes/params/envelopes/createEnvelope.ts

<ul><li>Change interface property from <code>paramValueRange</code> to <code>envPointValueRange</code><br> <li> Update parameter destructuring and usage throughout function<br> <li> Maintain consistency with envelope defaults property naming</ul>


</details>


  </td>
  <td><a href="https://github.com/KristinnRoach/sampler-monorepo/pull/141/files#diff-0b2adf3098315ad1b1099641df99d64dd59e50c81f13e6d6b5f0a489808a0774">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SampleVoice.ts</strong><dd><code>Fix filter envelope timing and cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/audiolib/src/nodes/instruments/Sample/SampleVoice.ts

<ul><li>Change <code>paramValueRange</code> to <code>envPointValueRange</code> in filter envelope <br>creation<br> <li> Fix timing parameter usage in HPF and LPF cutoff methods<br> <li> Remove playback rate condition checks from filter update methods<br> <li> Remove debug console warning statement</ul>


</details>


  </td>
  <td><a href="https://github.com/KristinnRoach/sampler-monorepo/pull/141/files#diff-06864f969c9eaede0095bdfc9244e0029dfa1ba40e4033071eea93c22f030e39">+7/-18</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced sustain-point handling when enabling sustain on loop for amp envelopes, improving playback behavior.

- Improvements
  - Smoother envelope editing via consistent point value-range handling.
  - Filter cutoff updates are more responsive and time-accurate across playback rates.
  - Reduced console noise.

- Breaking Changes
  - Envelope API rename: paramValueRange/valueRange → envPointValueRange/pointValueRange across envelope creation, data access, and customization. Update integrations accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->