### PR TITLE
fix shared KnobPresets and types to be framework agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,6 @@ pnpm watch
 pnpm build
 ```
 
-## Development
-
-Built as a final project for my BS in Computer Science at the University of Iceland, and further developed post-graduation to create a production-ready web application.
-
 ## License
 
 MIT

--- a/packages/audio-components/src/frameworks/shared/KnobPresets.tsx
+++ b/packages/audio-components/src/frameworks/shared/KnobPresets.tsx
@@ -1,19 +1,19 @@
-import { KnobComponentProps } from '../solidjs/primitives/knob/KnobComponent';
+import { SharedKnobComponentProps } from './types';
 // import { KnobChangeEventDetail } from '../../types';
 
-// ===== KNOB CONFIGURATIONS (KnobComponent-compatible) =====
+// ===== KNOB CONFIGURATIONS (Framework-agnostic) =====
 
-const volumeKnobProps: KnobComponentProps = {
+const volumeKnobProps: SharedKnobComponentProps = {
   label: 'Volume',
   defaultValue: 0.75,
 };
 
-const dryWetKnobProps: KnobComponentProps = {
+const dryWetKnobProps: SharedKnobComponentProps = {
   label: 'Dry/Wet',
   defaultValue: 0.5,
 };
 
-const feedbackKnobProps: KnobComponentProps = {
+const feedbackKnobProps: SharedKnobComponentProps = {
   label: 'Feedback',
   defaultValue: 0.0,
   minValue: 0,
@@ -23,7 +23,7 @@ const feedbackKnobProps: KnobComponentProps = {
   valueFormatter: (v: number) => v.toFixed(3),
 };
 
-const distortionKnobProps: KnobComponentProps = {
+const distortionKnobProps: SharedKnobComponentProps = {
   label: 'Distortion',
   defaultValue: 0.0,
   minValue: 0,
@@ -31,21 +31,21 @@ const distortionKnobProps: KnobComponentProps = {
   curve: 1.5,
 };
 
-const driveKnobProps: KnobComponentProps = {
+const driveKnobProps: SharedKnobComponentProps = {
   label: 'Drive',
   defaultValue: 0.0,
   minValue: 0,
   maxValue: 1,
 };
 
-const clippingKnobProps: KnobComponentProps = {
+const clippingKnobProps: SharedKnobComponentProps = {
   label: 'Clipping',
   defaultValue: 0.0,
   minValue: 0,
   maxValue: 1,
 };
 
-const glideKnobProps: KnobComponentProps = {
+const glideKnobProps: SharedKnobComponentProps = {
   label: 'Glide',
   defaultValue: 0.0,
   minValue: 0,
@@ -55,7 +55,7 @@ const glideKnobProps: KnobComponentProps = {
   valueFormatter: (v: number) => v.toFixed(3),
 };
 
-const feedbackPitchKnobProps: KnobComponentProps = {
+const feedbackPitchKnobProps: SharedKnobComponentProps = {
   label: 'FB-Pitch',
   defaultValue: 1.0,
   minValue: 0.25,
@@ -64,7 +64,7 @@ const feedbackPitchKnobProps: KnobComponentProps = {
   curve: 2,
 };
 
-const feedbackDecayKnobProps: KnobComponentProps = {
+const feedbackDecayKnobProps: SharedKnobComponentProps = {
   label: 'FB-Decay',
   defaultValue: 0.75,
   minValue: 0.01,
@@ -72,7 +72,7 @@ const feedbackDecayKnobProps: KnobComponentProps = {
   curve: 1.5,
 };
 
-const feedbackLpfKnobProps: KnobComponentProps = {
+const feedbackLpfKnobProps: SharedKnobComponentProps = {
   label: 'FB-LPF',
   defaultValue: 10000,
   minValue: 400,
@@ -81,7 +81,7 @@ const feedbackLpfKnobProps: KnobComponentProps = {
   valueFormatter: (v: number) => `${v.toFixed(0)} Hz`,
 };
 
-const delayTimeKnobProps: KnobComponentProps = {
+const delayTimeKnobProps: SharedKnobComponentProps = {
   label: 'Delay',
   defaultValue: 0.1,
   minValue: 0.005,
@@ -90,7 +90,7 @@ const delayTimeKnobProps: KnobComponentProps = {
   valueFormatter: (v: number) => `${v.toFixed(3)} s`,
 };
 
-const delayFBKnobProps: KnobComponentProps = {
+const delayFBKnobProps: SharedKnobComponentProps = {
   label: 'Delay Feedback',
   defaultValue: 0.25,
   minValue: 0,
@@ -99,7 +99,7 @@ const delayFBKnobProps: KnobComponentProps = {
   valueFormatter: (v: number) => `${(v * 100).toFixed(0)}%`,
 };
 
-const delaySendKnobProps: KnobComponentProps = {
+const delaySendKnobProps: SharedKnobComponentProps = {
   label: 'Delay Send',
   defaultValue: 0,
   minValue: 0,
@@ -108,33 +108,33 @@ const delaySendKnobProps: KnobComponentProps = {
   valueFormatter: (v: number) => `${(v * 100).toFixed(0)}%`,
 };
 
-const gainLFORateKnobProps: KnobComponentProps = {
+const gainLFORateKnobProps: SharedKnobComponentProps = {
   label: 'Amp LFO Rate',
   defaultValue: 0.1,
   curve: 5,
   snapIncrement: 0,
 };
 
-const gainLFODepthKnobProps: KnobComponentProps = {
+const gainLFODepthKnobProps: SharedKnobComponentProps = {
   label: 'Amp LFO Depth',
   defaultValue: 0.0,
   curve: 1.5,
 };
 
-const pitchLFORateKnobProps: KnobComponentProps = {
+const pitchLFORateKnobProps: SharedKnobComponentProps = {
   label: 'Pitch LFO Rate',
   defaultValue: 0.01,
   curve: 5,
   snapIncrement: 0,
 };
 
-const pitchLFODepthKnobProps: KnobComponentProps = {
+const pitchLFODepthKnobProps: SharedKnobComponentProps = {
   label: 'Pitch LFO Depth',
   defaultValue: 0.0,
   curve: 1.5,
 };
 
-const reverbSendKnobProps: KnobComponentProps = {
+const reverbSendKnobProps: SharedKnobComponentProps = {
   label: 'Reverb Send',
   defaultValue: 0,
   minValue: 0,
@@ -143,13 +143,13 @@ const reverbSendKnobProps: KnobComponentProps = {
   valueFormatter: (v: number) => `${(v * 100).toFixed(1)}%`,
 };
 
-const reverbSizeKnobProps: KnobComponentProps = {
+const reverbSizeKnobProps: SharedKnobComponentProps = {
   label: 'Reverb Size',
   defaultValue: 0.7,
   curve: 1,
 };
 
-const loopDurationDriftKnobProps: KnobComponentProps = {
+const loopDurationDriftKnobProps: SharedKnobComponentProps = {
   label: 'Loop Drift',
   defaultValue: 0.3,
   minValue: 0,
@@ -159,7 +159,7 @@ const loopDurationDriftKnobProps: KnobComponentProps = {
   valueFormatter: (v: number) => `${(v * 100).toFixed(1)}%`,
 };
 
-const lowpassFilterKnobProps: KnobComponentProps = {
+const lowpassFilterKnobProps: SharedKnobComponentProps = {
   label: 'LPF',
   defaultValue: 20000,
   minValue: 40,
@@ -168,7 +168,7 @@ const lowpassFilterKnobProps: KnobComponentProps = {
   valueFormatter: (v: number) => `${v.toFixed(0)} Hz`,
 };
 
-const highpassFilterKnobProps: KnobComponentProps = {
+const highpassFilterKnobProps: SharedKnobComponentProps = {
   label: 'HPF',
   defaultValue: 40,
   minValue: 20,
@@ -176,7 +176,7 @@ const highpassFilterKnobProps: KnobComponentProps = {
   curve: 5,
 };
 
-const amplitudeModKnobProps: KnobComponentProps = {
+const amplitudeModKnobProps: SharedKnobComponentProps = {
   label: 'AM',
   defaultValue: 0,
   minValue: 0,
@@ -184,21 +184,21 @@ const amplitudeModKnobProps: KnobComponentProps = {
   curve: 1,
 };
 
-const trimStartKnobProps: KnobComponentProps = {
+const trimStartKnobProps: SharedKnobComponentProps = {
   label: 'Start',
   defaultValue: 0,
   snapIncrement: 0.001,
   valueFormatter: (v: number) => v.toFixed(3),
 };
 
-const trimEndKnobProps: KnobComponentProps = {
+const trimEndKnobProps: SharedKnobComponentProps = {
   label: 'End',
   defaultValue: 1,
   snapIncrement: 0.001,
   valueFormatter: (v: number) => v.toFixed(3),
 };
 
-const loopStartKnobProps: KnobComponentProps = {
+const loopStartKnobProps: SharedKnobComponentProps = {
   label: 'Loop Start',
   defaultValue: 0,
   minValue: 0,
@@ -206,7 +206,7 @@ const loopStartKnobProps: KnobComponentProps = {
   valueFormatter: (v: number) => v.toFixed(3),
 };
 
-const loopDurationKnobProps: KnobComponentProps = {
+const loopDurationKnobProps: SharedKnobComponentProps = {
   label: 'Loop Length',
   defaultValue: 1,
   minValue: 0,
@@ -215,7 +215,7 @@ const loopDurationKnobProps: KnobComponentProps = {
   snapIncrement: 0,
 };
 
-const tempoKnobProps: KnobComponentProps = {
+const tempoKnobProps: SharedKnobComponentProps = {
   label: 'Tempo',
   defaultValue: 120,
   minValue: 20,

--- a/packages/audio-components/src/frameworks/shared/types.ts
+++ b/packages/audio-components/src/frameworks/shared/types.ts
@@ -1,0 +1,39 @@
+// src/frameworks/shared/types.ts
+import { KnobConfig } from '../../elements/primitives/KnobElement';
+
+/**
+ * Framework-agnostic props interface for knob presets and shared components.
+ * This interface extends the core KnobConfig but excludes framework-specific
+ * properties like refs, event handlers, and styling classes.
+ */
+export interface SharedKnobComponentProps extends Partial<KnobConfig> {
+  // UI props that are framework-agnostic
+  label?: string;
+  valueFormatter?: (value: number) => string;
+
+  // Display configuration
+  displayValue?: boolean;
+
+  // Tooltip support
+  title?: string;
+
+  // Core preset-compatible properties
+  preset?: string; // Will be typed more specifically by consumers
+  size?: number;
+  color?: string;
+  value?: number;
+
+  // Note: Framework-specific properties like:
+  // - ref (varies between React.Ref vs (el: KnobElement) => void)
+  // - className/class (React vs SolidJS naming)
+  // - style (React.CSSProperties vs string | Record<string, string>)
+  // - onChange (framework-specific event handling)
+  // are intentionally excluded to maintain framework-agnosticism
+}
+
+// Re-export core types for convenience
+export type {
+  KnobConfig,
+  KnobChangeEventDetail,
+  KnobFactoryOptions,
+} from '../../elements/primitives/KnobElement';


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Refactor knob presets to be framework-agnostic

- Create shared types interface for cross-framework compatibility

- Remove framework-specific dependencies from shared components

- Clean up README development section


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Framework-specific KnobComponentProps"] --> B["SharedKnobComponentProps"]
  B --> C["Framework-agnostic KnobPresets"]
  D["SolidJS types"] --> B
  E["React types"] --> B
  B --> F["Cross-framework compatibility"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.ts</strong><dd><code>Add framework-agnostic shared types interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/audio-components/src/frameworks/shared/types.ts

<ul><li>Create new <code>SharedKnobComponentProps</code> interface extending <code>KnobConfig</code><br> <li> Define framework-agnostic properties for knob components<br> <li> Re-export core types from <code>KnobElement</code> for convenience<br> <li> Document excluded framework-specific properties</ul>


</details>


  </td>
  <td><a href="https://github.com/KristinnRoach/sampler-monorepo/pull/160/files#diff-5fa63579007f97c9315598fa658737d798f2cd286951ee7479c2d2421bc43710">+39/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>KnobPresets.tsx</strong><dd><code>Convert knob presets to framework-agnostic types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/audio-components/src/frameworks/shared/KnobPresets.tsx

<ul><li>Replace <code>KnobComponentProps</code> import with <code>SharedKnobComponentProps</code><br> <li> Update all knob preset configurations to use shared types<br> <li> Maintain existing preset configurations and properties</ul>


</details>


  </td>
  <td><a href="https://github.com/KristinnRoach/sampler-monorepo/pull/160/files#diff-1237c3a565247fee69adedf205c09cb0bd5dd86f3258147e17aa9000550de39b">+30/-30</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Clean up README development section</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

- Remove development section about university project background


</details>


  </td>
  <td><a href="https://github.com/KristinnRoach/sampler-monorepo/pull/160/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a framework-agnostic knob props interface for easier cross-framework use.
  - Exported common knob-related types for convenient consumption.
- Refactor
  - Updated all knob presets to use the shared interface with normalized properties (e.g., ranges, formatting, snapping).
  - Preset names/keys remain unchanged; no expected behavioral changes.
- Documentation
  - Removed the “Development” section from the README; build and runtime instructions remain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->