### PR TITLE
Audio output device selection + gain staging fix

### DIFF
--- a/apps/play/package.json
+++ b/apps/play/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@repo/audio-components": "workspace:*",
+    "@repo/audiolib": "workspace:*",
     "@repo/input-controller": "workspace:*",
     "clsx": "^2.1.1",
     "dexie": "^4.0.11",

--- a/apps/play/src/App.tsx
+++ b/apps/play/src/App.tsx
@@ -23,6 +23,7 @@ import Accordion from './components/Accordion';
 import SampleListSection from './components/SampleListSection';
 import BaseButton from './components/Button';
 import RowCollapseIcons from './components/RowCollapseIcons';
+import OutputDeviceSelect from './components/OutputDeviceSelect';
 
 const App: Component = () => {
   const [layout, setLayout] = createSignal<LayoutType>('desktop');
@@ -182,6 +183,10 @@ const App: Component = () => {
             <ThemeToggle
               class={`toolbar-btn ${toolbarOpen() ? '__toolbar-open' : ''}`}
               defaultTheme='light'
+            />
+
+            <OutputDeviceSelect
+              class={`toolbar-btn output-device-select ${toolbarOpen() ? '__toolbar-open' : ''}`}
             />
 
             {/* <tempo-knob

--- a/apps/play/src/components/OutputDeviceSelect.tsx
+++ b/apps/play/src/components/OutputDeviceSelect.tsx
@@ -23,7 +23,7 @@ interface OutputDeviceSelectProps {
  *  Hidden entirely on browsers without AudioContext.setSinkId (Safari). */
 const OutputDeviceSelect: Component<OutputDeviceSelectProps> = (props) => {
   const [devices, setDevices] = createSignal<MediaDeviceInfo[]>([]);
-  const [selected, setSelected] = createSignal(getCurrentOutputDeviceId());
+  const [selected, setSelected] = createSignal('');
 
   const refresh = async () => setDevices(await getAudioOutputDevices());
 

--- a/apps/play/src/components/OutputDeviceSelect.tsx
+++ b/apps/play/src/components/OutputDeviceSelect.tsx
@@ -1,5 +1,13 @@
 // components/OutputDeviceSelect.tsx
-import { Component, For, Show, createSignal, onCleanup, onMount } from 'solid-js';
+import {
+  Component,
+  For,
+  Show,
+  createMemo,
+  createSignal,
+  onCleanup,
+  onMount,
+} from 'solid-js';
 import {
   canSetOutputDevice,
   getAudioOutputDevices,
@@ -39,7 +47,15 @@ const OutputDeviceSelect: Component<OutputDeviceSelectProps> = (props) => {
     refresh();
     navigator.mediaDevices.addEventListener('devicechange', refresh);
     onCleanup(() =>
-      navigator.mediaDevices.removeEventListener('devicechange', refresh)
+      navigator.mediaDevices.removeEventListener('devicechange', refresh),
+    );
+  });
+
+  const selectedLabel = createMemo(() => {
+    if (!selected()) return 'System Default Output';
+    return (
+      devices().find((d) => d.deviceId === selected())?.label ||
+      'Audio output device'
     );
   });
 
@@ -55,16 +71,36 @@ const OutputDeviceSelect: Component<OutputDeviceSelectProps> = (props) => {
   return (
     <Show when={canSetOutputDevice()}>
       <select
-        title='Audio output device'
+        aria-label='Audio output device'
+        title={selectedLabel()}
         class={props.class}
         value={selected()}
         onfocus={refreshWithPermission}
         onchange={(e) => onChange(e.currentTarget.value)}
       >
-        <option value=''>System Default Output</option>
+        <button type='button'>
+          <svg
+            aria-hidden='true'
+            viewBox='0 0 24 24'
+            width='20'
+            height='20'
+            fill='none'
+            stroke='currentColor'
+            stroke-width='2'
+            stroke-linecap='round'
+            stroke-linejoin='round'
+          >
+            <path d='M11 5 6 9H3v6h3l5 4z' />
+            <path d='M15.5 8.5a5 5 0 0 1 0 7' />
+            <path d='M18.5 5.5a9 9 0 0 1 0 13' />
+          </svg>
+        </button>
+        <option value='' selected={!selected()}>System Default Output</option>
         <For each={devices().filter((d) => d.deviceId !== 'default')}>
           {(d, i) => (
-            <option value={d.deviceId}>{d.label || `Output ${i() + 1}`}</option>
+            <option value={d.deviceId} selected={selected() === d.deviceId}>
+              {d.label || `Output ${i() + 1}`}
+            </option>
           )}
         </For>
       </select>

--- a/apps/play/src/components/OutputDeviceSelect.tsx
+++ b/apps/play/src/components/OutputDeviceSelect.tsx
@@ -1,0 +1,75 @@
+// components/OutputDeviceSelect.tsx
+import { Component, For, Show, createSignal, onCleanup, onMount } from 'solid-js';
+import {
+  canSetOutputDevice,
+  getAudioOutputDevices,
+  setAudioOutputDevice,
+  getCurrentOutputDeviceId,
+} from '@repo/audiolib';
+
+interface OutputDeviceSelectProps {
+  class?: string;
+}
+
+/** Routes the app's audio output to a chosen device (e.g. BlackHole -> DAW).
+ *  Hidden entirely on browsers without AudioContext.setSinkId (Safari). */
+const OutputDeviceSelect: Component<OutputDeviceSelectProps> = (props) => {
+  const [devices, setDevices] = createSignal<MediaDeviceInfo[]>([]);
+  const [selected, setSelected] = createSignal(getCurrentOutputDeviceId());
+
+  const refresh = async () => setDevices(await getAudioOutputDevices());
+
+  // Chrome only exposes the full labeled output list once mic permission is
+  // granted, so request it on user interaction if the list looks gated.
+  const refreshWithPermission = async () => {
+    await refresh();
+    const gated = devices().every((d) => !d.label);
+    if (!gated) return;
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      stream.getTracks().forEach((t) => t.stop());
+      await refresh();
+    } catch {
+      // permission denied — keep the unlabeled list
+    }
+  };
+
+  onMount(() => {
+    if (!canSetOutputDevice()) return;
+    refresh();
+    navigator.mediaDevices.addEventListener('devicechange', refresh);
+    onCleanup(() =>
+      navigator.mediaDevices.removeEventListener('devicechange', refresh)
+    );
+  });
+
+  const onChange = async (deviceId: string) => {
+    try {
+      await setAudioOutputDevice(deviceId);
+      setSelected(deviceId);
+    } catch (err) {
+      console.error('Failed to set output device', err);
+    }
+  };
+
+  return (
+    <Show when={canSetOutputDevice()}>
+      <select
+        title='Audio output device'
+        class={props.class}
+        value={selected()}
+        onfocus={refreshWithPermission}
+        onchange={(e) => onChange(e.currentTarget.value)}
+      >
+        <option value=''>System Default Output</option>
+        <For each={devices().filter((d) => d.deviceId !== 'default')}>
+          {(d, i) => (
+            <option value={d.deviceId}>{d.label || `Output ${i() + 1}`}</option>
+          )}
+        </For>
+      </select>
+    </Show>
+  );
+};
+
+export default OutputDeviceSelect;

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -724,7 +724,7 @@ piano-keyboard.visible {
   opacity: 1;
 
   &:hover {
-    transform: scale(1.2);
+    transform: scale(1.1);
   }
 
   &:active {
@@ -747,21 +747,35 @@ piano-keyboard.visible {
     border: none !important;
   }
   &:hover {
-    transform: scale(1.1) !important;
+    transform: scale(1.05) !important;
   }
 }
 
 .toolbar-wrapper > .expandable-width > .output-device-select {
-  width: auto;
-  max-width: 160px;
-  background-color: inherit;
+  appearance: base-select;
+  max-width: 36px;
+  white-space: nowrap;
+  overflow: hidden;
   color: white;
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  border-radius: 4px;
-  font-size: 12px;
+
+  &:open {
+    transform: scale(0.9);
+    color: rgb(85, 136, 255);
+  }
 
   & option {
-    color: black;
+    font-family: monospace;
+    font-size: 12px;
+  }
+
+  & option:checked {
+    color: rgb(85, 136, 255);
+    background: rgba(0, 0, 0, 0.529);
+    outline: 1px solid rgb(85, 136, 255);
+  }
+
+  &::picker-icon {
+    display: none;
   }
 }
 

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -751,6 +751,20 @@ piano-keyboard.visible {
   }
 }
 
+.toolbar-wrapper > .expandable-width > .output-device-select {
+  width: auto;
+  max-width: 160px;
+  background-color: inherit;
+  color: white;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 4px;
+  font-size: 12px;
+
+  & option {
+    color: black;
+  }
+}
+
 .theme-toggle {
   font-size: 20px;
 }

--- a/packages/audiolib/src/context/globalAudioContext.test.ts
+++ b/packages/audiolib/src/context/globalAudioContext.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+async function loadWithSinkId(sinkId: string | { readonly type: 'none' }) {
+  class FakeAudioContext {
+    state = 'running';
+    sinkId = sinkId;
+    audioWorklet = {};
+
+    createGain() {
+      return { gain: { cancelAndHoldAtTime: () => undefined } };
+    }
+
+    close() {
+      return Promise.resolve();
+    }
+  }
+
+  vi.stubGlobal('window', { AudioContext: FakeAudioContext });
+  vi.stubGlobal('AudioContext', FakeAudioContext);
+
+  return import('./globalAudioContext');
+}
+
+describe('getCurrentOutputDeviceId', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns string sink ids', async () => {
+    const { getCurrentOutputDeviceId } = await loadWithSinkId('speaker-1');
+
+    expect(getCurrentOutputDeviceId()).toBe('speaker-1');
+  });
+
+  it('returns no device id for AudioSinkInfo silent output', async () => {
+    const { getCurrentOutputDeviceId } = await loadWithSinkId({ type: 'none' });
+
+    expect(getCurrentOutputDeviceId()).toBe('');
+  });
+});

--- a/packages/audiolib/src/context/globalAudioContext.ts
+++ b/packages/audiolib/src/context/globalAudioContext.ts
@@ -108,6 +108,14 @@ export async function setAudioOutputDevice(deviceId: string): Promise<void> {
   );
   const ctx = (await ensureAudioCtx()) as SinkCapableContext;
   await ctx.setSinkId(deviceId === 'default' ? '' : deviceId);
+
+  // TEMP DEBUG: volume tracing — remove after gain staging is fixed
+  const dest = ctx.destination;
+  console.log(
+    `[sink] sinkId="${ctx.sinkId}" sampleRate=${ctx.sampleRate} ` +
+      `dest.channelCount=${dest.channelCount} dest.maxChannelCount=${dest.maxChannelCount} ` +
+      `state=${ctx.state} baseLatency=${ctx.baseLatency}`
+  );
 }
 
 export function getCurrentOutputDeviceId(): string {

--- a/packages/audiolib/src/context/globalAudioContext.ts
+++ b/packages/audiolib/src/context/globalAudioContext.ts
@@ -78,6 +78,43 @@ function setupAutoResume(): Promise<void> {
   });
 }
 
+// --- Output device selection ---
+
+type SinkCapableContext = AudioContext & {
+  setSinkId(id: string): Promise<void>;
+  sinkId: string;
+};
+
+/** False in Safari — AudioContext.setSinkId is Chromium/Firefox only */
+export function canSetOutputDevice(): boolean {
+  return (
+    typeof AudioContext !== 'undefined' &&
+    'setSinkId' in AudioContext.prototype
+  );
+}
+
+/** Device labels are only populated once mic permission has been granted */
+export async function getAudioOutputDevices(): Promise<MediaDeviceInfo[]> {
+  const devices = await navigator.mediaDevices.enumerateDevices();
+  return devices.filter((d) => d.kind === 'audiooutput');
+}
+
+/** Routes the global AudioContext (all audiolib output) to the given output device.
+ *  Pass '' or 'default' to restore the system default output. */
+export async function setAudioOutputDevice(deviceId: string): Promise<void> {
+  assert(
+    canSetOutputDevice(),
+    'AudioContext.setSinkId is not supported in this browser'
+  );
+  const ctx = (await ensureAudioCtx()) as SinkCapableContext;
+  await ctx.setSinkId(deviceId === 'default' ? '' : deviceId);
+}
+
+export function getCurrentOutputDeviceId(): string {
+  const ctx = getAudioContext() as Partial<SinkCapableContext>;
+  return typeof ctx.sinkId === 'string' ? ctx.sinkId : '';
+}
+
 export async function decodeAudioData(
   arrayBuffer: ArrayBuffer,
   config?: AudioContextConfig

--- a/packages/audiolib/src/context/globalAudioContext.ts
+++ b/packages/audiolib/src/context/globalAudioContext.ts
@@ -81,9 +81,15 @@ function setupAutoResume(): Promise<void> {
 // --- Output device selection ---
 
 type SinkCapableContext = AudioContext & {
-  setSinkId(id: string): Promise<void>;
-  sinkId: string;
+  setSinkId(id: AudioContextSinkId): Promise<void>;
+  sinkId: AudioContextSinkId;
 };
+
+type AudioSinkInfo = {
+  readonly type: 'none';
+};
+
+type AudioContextSinkId = string | AudioSinkInfo;
 
 /** False in Safari — AudioContext.setSinkId is Chromium/Firefox only */
 export function canSetOutputDevice(): boolean {
@@ -112,7 +118,14 @@ export async function setAudioOutputDevice(deviceId: string): Promise<void> {
 
 export function getCurrentOutputDeviceId(): string {
   const ctx = getAudioContext() as Partial<SinkCapableContext>;
-  return typeof ctx.sinkId === 'string' ? ctx.sinkId : '';
+  const { sinkId } = ctx;
+  if (typeof sinkId === 'string') {
+    return sinkId;
+  }
+  if (sinkId?.type === 'none') {
+    return '';
+  }
+  return '';
 }
 
 export async function decodeAudioData(

--- a/packages/audiolib/src/context/globalAudioContext.ts
+++ b/packages/audiolib/src/context/globalAudioContext.ts
@@ -108,14 +108,6 @@ export async function setAudioOutputDevice(deviceId: string): Promise<void> {
   );
   const ctx = (await ensureAudioCtx()) as SinkCapableContext;
   await ctx.setSinkId(deviceId === 'default' ? '' : deviceId);
-
-  // TEMP DEBUG: volume tracing — remove after gain staging is fixed
-  const dest = ctx.destination;
-  console.log(
-    `[sink] sinkId="${ctx.sinkId}" sampleRate=${ctx.sampleRate} ` +
-      `dest.channelCount=${dest.channelCount} dest.maxChannelCount=${dest.maxChannelCount} ` +
-      `state=${ctx.state} baseLatency=${ctx.baseLatency}`
-  );
 }
 
 export function getCurrentOutputDeviceId(): string {

--- a/packages/audiolib/src/index.ts
+++ b/packages/audiolib/src/index.ts
@@ -18,6 +18,12 @@ export type {
 
 // =*=*= Utilities =*=*= \\
 export { getAudioContext, ensureAudioCtx } from './context';
+export {
+  canSetOutputDevice,
+  getAudioOutputDevices,
+  setAudioOutputDevice,
+  getCurrentOutputDeviceId,
+} from './context';
 
 // =*=*= Constants =*=*= \\
 export { SUPPORTED_WAVEFORMS } from './utils';

--- a/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
+++ b/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
@@ -183,6 +183,37 @@ export class SamplePlayer implements ILibInstrumentNode {
     this.voicePool.connect(this.outBus.input);
     this.outBus.connect(this.#masterOut);
     this.#masterOut.connect(this.context.destination);
+
+    // TEMP DEBUG: volume tracing — remove after gain staging is fixed
+    this.#tapLevel('A post-busInput (voices x0.5)', this.outBus.input);
+    this.#tapLevel('B post-busChain', this.outBus.output);
+    this.#tapLevel('C final (post volume knob)', this.#masterOut);
+  }
+
+  // TEMP DEBUG: logs peak dBFS at a point in the chain while signal is present
+  #tapLevel(label: string, node: AudioNode) {
+    // fftSize 32768 = ~683ms window @48k, polled every 400ms -> gapless peak coverage
+    const an = new AnalyserNode(this.context, { fftSize: 32768 });
+    node.connect(an);
+    const buf = new Float32Array(an.fftSize);
+    let notePeak = 0;
+    setInterval(() => {
+      an.getFloatTimeDomainData(buf);
+      let peak = 0;
+      for (let i = 0; i < buf.length; i++) {
+        const a = Math.abs(buf[i]);
+        if (a > peak) peak = a;
+      }
+      if (peak > 1e-4) {
+        notePeak = Math.max(notePeak, peak);
+        console.log(
+          `[level] ${label}: ${(20 * Math.log10(peak)).toFixed(1)} dBFS ` +
+            `(note peak so far: ${(20 * Math.log10(notePeak)).toFixed(1)})`
+        );
+      } else {
+        notePeak = 0; // silence resets per-note peak
+      }
+    }, 400);
   }
 
   setRecorderInputSource(source: InputSource) {

--- a/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
+++ b/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
@@ -183,37 +183,6 @@ export class SamplePlayer implements ILibInstrumentNode {
     this.voicePool.connect(this.outBus.input);
     this.outBus.connect(this.#masterOut);
     this.#masterOut.connect(this.context.destination);
-
-    // TEMP DEBUG: volume tracing — remove after gain staging is fixed
-    this.#tapLevel('A post-busInput (voices x0.5)', this.outBus.input);
-    this.#tapLevel('B post-busChain', this.outBus.output);
-    this.#tapLevel('C final (post volume knob)', this.#masterOut);
-  }
-
-  // TEMP DEBUG: logs peak dBFS at a point in the chain while signal is present
-  #tapLevel(label: string, node: AudioNode) {
-    // fftSize 32768 = ~683ms window @48k, polled every 400ms -> gapless peak coverage
-    const an = new AnalyserNode(this.context, { fftSize: 32768 });
-    node.connect(an);
-    const buf = new Float32Array(an.fftSize);
-    let notePeak = 0;
-    setInterval(() => {
-      an.getFloatTimeDomainData(buf);
-      let peak = 0;
-      for (let i = 0; i < buf.length; i++) {
-        const a = Math.abs(buf[i]);
-        if (a > peak) peak = a;
-      }
-      if (peak > 1e-4) {
-        notePeak = Math.max(notePeak, peak);
-        console.log(
-          `[level] ${label}: ${(20 * Math.log10(peak)).toFixed(1)} dBFS ` +
-            `(note peak so far: ${(20 * Math.log10(notePeak)).toFixed(1)})`
-        );
-      } else {
-        notePeak = 0; // silence resets per-note peak
-      }
-    }, 400);
   }
 
   setRecorderInputSource(source: InputSource) {

--- a/packages/audiolib/src/nodes/master/InstrumentBus.ts
+++ b/packages/audiolib/src/nodes/master/InstrumentBus.ts
@@ -101,7 +101,7 @@ export class InstrumentBus implements ILibAudioNode {
     this.#initPromise = (async () => {
       try {
         // Create nodes
-        const input = this.createGainNode(this.#context, { initialGain: 0.5 });
+        const input = this.createGainNode(this.#context, { initialGain: 1 });
         const dryMix = this.createGainNode(this.#context, { initialGain: 1 });
         const wetMix = this.createGainNode(this.#context, { initialGain: 1 });
         const output = this.createGainNode(this.#context, { initialGain: 1 });

--- a/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
+++ b/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
@@ -257,7 +257,7 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
     this.isReleasing = false;
     this.loopEnabled = false;
     this.transpositionPlaybackrate = 1;
-    this.velocitySensitivity = 0.5;
+    this.velocitySensitivity = 1.0; // full velocity = unity gain
 
     this.reversePlayback = false;
     this.playbackPosition = 0;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@repo/audio-components':
         specifier: workspace:*
         version: link:../../packages/audio-components
+      '@repo/audiolib':
+        specifier: workspace:*
+        version: link:../../packages/audiolib
       '@repo/input-controller':
         specifier: workspace:*
         version: link:../../packages/input-controller


### PR DESCRIPTION
## What

- **Output device selection** (`AudioContext.setSinkId`): new audiolib API — `getAudioOutputDevices`, `setAudioOutputDevice`, `canSetOutputDevice`, `getCurrentOutputDeviceId` — operating on the shared global AudioContext.
- **play app**: `OutputDeviceSelect` toolbar dropdown. Requests mic permission on open when device labels are permission-gated, refreshes on devicechange, hidden on browsers without setSinkId (Safari).
- **Gain staging fix (+12 dB at source)**: worklet `velocitySensitivity` 0.5 -> 1.0 (full velocity = unity gain) and InstrumentBus input gain 0.5 -> 1.0. Output peaked ~-21 dBFS even at max volume; now ~-9 dBFS at default velocity.

## Why

Enables routing app audio to a virtual device (e.g. BlackHole) for DAW capture, and fixes chronically low output level.

## Verified

- Levels measured at three chain points: device-independent (identical on speakers vs BlackHole 16ch).
- Bus compressor engages ~0.5 dB post-fix; no audible pumping on single notes.
- tsc + worklet build + full app build pass.

Note: heavy chords now hit the bus limiter harder than before; if pumping shows up in practice, soften limiter/ratio in a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a browser audio output selector so users can switch playback to different speakers/devices when supported.
  * Improved audio handling to better reflect the selected output device and current device list.

* **Bug Fixes**
  * Updated default audio levels so playback starts louder and MIDI velocity responds more naturally after reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->