### PR TITLE
Investigate sample release click

### DIFF
--- a/packages/audiolib/src/nodes/instruments/Sample/SampleVoice.ts
+++ b/packages/audiolib/src/nodes/instruments/Sample/SampleVoice.ts
@@ -13,6 +13,7 @@ import {
 import {
   assert,
   clamp,
+  cancelScheduledParamValues,
   interpolateLinearToExp,
   mapToRange,
   midiToPlaybackRate,
@@ -430,6 +431,7 @@ export class SampleVoice {
   }
 
   #releaseTimeout: number | null = null;
+  #stopTimeout: number | null = null;
 
   release({ releaseTime = this.releaseTime, secondsFromNow = 0 }): this {
     if (this.#state === VoiceState.RELEASING) return this;
@@ -501,14 +503,22 @@ export class SampleVoice {
     }
     this.#state = VoiceState.STOPPING;
 
-    // Clear all scheduled values to prevent overlapping setValueCurveAtTime errors
-    this.setParam('envGain', 0, timestamp, {
-      cancelPrevious: true,
-      glideTime: 0,
-    });
+    const deClickSeconds = 0.005;
+    const stopAt = Math.max(timestamp, this.now);
+    const envGain = this.getParam('envGain');
+    if (envGain) {
+      cancelScheduledParamValues(envGain, stopAt);
+      envGain.linearRampToValueAtTime(0, stopAt + deClickSeconds);
+    }
 
-    this.sendToProcessor({ type: 'voice:stop', timestamp });
-    this.#state = VoiceState.STOPPED;
+    if (this.#stopTimeout) clearTimeout(this.#stopTimeout);
+    this.#stopTimeout = setTimeout(
+      () => {
+        this.sendToProcessor({ type: 'voice:stop', timestamp: stopAt });
+        this.#stopTimeout = null;
+      },
+      Math.max(0, (stopAt + deClickSeconds - this.now) * 1000)
+    );
     return this;
   }
 
@@ -1207,6 +1217,7 @@ export class SampleVoice {
     this.#envelopes.forEach((env) => env.dispose());
     this.#playerWorklet.port.close();
     if (this.#releaseTimeout) clearTimeout(this.#releaseTimeout);
+    if (this.#stopTimeout) clearTimeout(this.#stopTimeout);
     unregisterNode(this.nodeId);
   }
 

--- a/packages/audiolib/src/nodes/instruments/Sample/SampleVoice.ts
+++ b/packages/audiolib/src/nodes/instruments/Sample/SampleVoice.ts
@@ -13,7 +13,7 @@ import {
 import {
   assert,
   clamp,
-  cancelScheduledParamValues,
+  cancelAndPinParamValue,
   interpolateLinearToExp,
   mapToRange,
   midiToPlaybackRate,
@@ -507,7 +507,7 @@ export class SampleVoice {
     const stopAt = Math.max(timestamp, this.now);
     const envGain = this.getParam('envGain');
     if (envGain) {
-      cancelScheduledParamValues(envGain, stopAt);
+      cancelAndPinParamValue(envGain, stopAt);
       envGain.linearRampToValueAtTime(0, stopAt + deClickSeconds);
     }
 

--- a/packages/audiolib/src/nodes/instruments/Sample/SampleVoice.ts
+++ b/packages/audiolib/src/nodes/instruments/Sample/SampleVoice.ts
@@ -990,6 +990,10 @@ export class SampleVoice {
           );
           break;
 
+        case 'debug:release':
+          console.debug('SampleVoice release debug:', data);
+          break;
+
         case 'debug:loop':
           console.log('Loop debug:', data);
           break;

--- a/packages/audiolib/src/nodes/params/envelopes/CustomEnvelope.ts
+++ b/packages/audiolib/src/nodes/params/envelopes/CustomEnvelope.ts
@@ -48,7 +48,7 @@ export class CustomEnvelope implements LibNode {
     initialPoints: EnvelopePoint[] = [],
     envPointValueRange: [number, number] = [0, 1],
     durationSeconds = 1,
-    initEnable = true
+    initEnable = true,
   ) {
     this.envelopeType = envelopeType;
     this.nodeType = envelopeType;
@@ -72,7 +72,7 @@ export class CustomEnvelope implements LibNode {
         break;
       default:
         console.error(
-          `CustomEnvelope not implemented for type: ${envelopeType}`
+          `CustomEnvelope not implemented for type: ${envelopeType}`,
         );
         this.#paramName = 'default';
         break;
@@ -94,7 +94,7 @@ export class CustomEnvelope implements LibNode {
   addPoint = (
     time: number,
     value: number,
-    curve?: 'linear' | 'exponential'
+    curve?: 'linear' | 'exponential',
   ): void => {
     this.#data.addPoint(time, value, curve);
     if (this.#isCurrentlyLooping) this.#loopUpdateFlag = true;
@@ -180,7 +180,7 @@ export class CustomEnvelope implements LibNode {
     fromIdx = this.#data.startPointIndex,
     toIdx = this.#data.endPointIndex,
     playbackRate = this.#currentPlaybackRate,
-    timeScale = this.#timeScale
+    timeScale = this.#timeScale,
   ): number {
     if (
       fromIdx < this.#data.startPointIndex ||
@@ -230,7 +230,7 @@ export class CustomEnvelope implements LibNode {
       maxValue: number;
       playbackRate?: number;
       startFromValue?: number;
-    }
+    },
   ): Float32Array {
     const sampleRate = this.#getCurveSamplingRate(scaledDuration);
     const numSamples = Math.max(2, Math.floor(scaledDuration * sampleRate));
@@ -279,7 +279,7 @@ export class CustomEnvelope implements LibNode {
       playbackRate: number;
       voiceId?: string;
       midiNote?: number;
-    } = { baseValue: 1, playbackRate: 1 }
+    } = { baseValue: 1, playbackRate: 1 },
   ) {
     // Firefox fallback - use extremely simple envelope behavior
     if (this.#isFirefox) {
@@ -293,11 +293,11 @@ export class CustomEnvelope implements LibNode {
         // Simple attack and decay
         audioParam.linearRampToValueAtTime(
           options.baseValue * 0.8,
-          safeStart + 0.01
+          safeStart + 0.01,
         );
         audioParam.linearRampToValueAtTime(
           options.baseValue * 0.5,
-          safeStart + 0.1
+          safeStart + 0.1,
         );
 
         console.debug('Firefox trigger envelope - simple linear ramps');
@@ -357,7 +357,7 @@ export class CustomEnvelope implements LibNode {
       playbackRate: number;
       voiceId?: string;
       midiNote?: number;
-    }
+    },
   ) {
     const endIdx = this.sustainEnabled
       ? (this.sustainPointIndex ?? this.points.length - 1)
@@ -367,7 +367,7 @@ export class CustomEnvelope implements LibNode {
       0,
       endIdx,
       options.playbackRate,
-      this.#timeScale
+      this.#timeScale,
     );
 
     const curve = this.#generateCurve(
@@ -380,7 +380,7 @@ export class CustomEnvelope implements LibNode {
         minValue: audioParam.minValue,
         maxValue: audioParam.maxValue,
         startFromValue: audioParam.value,
-      }
+      },
     );
 
     if (options.voiceId !== undefined) {
@@ -402,7 +402,7 @@ export class CustomEnvelope implements LibNode {
     if (scaledDuration < 0.005) {
       audioParam.linearRampToValueAtTime(
         curve[curve.length - 1],
-        safeStart + scaledDuration
+        safeStart + scaledDuration,
       );
       return;
     }
@@ -417,7 +417,7 @@ export class CustomEnvelope implements LibNode {
           () => {
             this.#activeEnvelope = null;
           },
-          scaledDuration * 1000 + 100
+          scaledDuration * 1000 + 100,
         ); // Small buffer to ensure completion
       }
     } catch (error) {
@@ -427,7 +427,7 @@ export class CustomEnvelope implements LibNode {
 
         audioParam.linearRampToValueAtTime(
           curve[curve.length - 1],
-          safeStart + scaledDuration
+          safeStart + scaledDuration,
         );
 
         // Clear active envelope state for fallback case too
@@ -436,7 +436,7 @@ export class CustomEnvelope implements LibNode {
             () => {
               this.#activeEnvelope = null;
             },
-            scaledDuration * 1000 + 100
+            scaledDuration * 1000 + 100,
           );
         }
       } catch (fallbackError) {
@@ -478,7 +478,7 @@ export class CustomEnvelope implements LibNode {
       midiNote?: number;
       minValue?: number;
       maxValue?: number;
-    }
+    },
   ) {
     if (!this.#shouldLoop()) {
       this.#isCurrentlyLooping = false;
@@ -489,7 +489,7 @@ export class CustomEnvelope implements LibNode {
       this.#data.startPointIndex,
       this.#data.endPointIndex,
       options.playbackRate,
-      this.#timeScale
+      this.#timeScale,
     );
 
     let cachedCurve = this.#generateCurve(cachedDuration, this.baseDuration, {
@@ -544,7 +544,7 @@ export class CustomEnvelope implements LibNode {
             this.#data.startPointIndex,
             this.#data.endPointIndex,
             options.playbackRate,
-            this.#timeScale
+            this.#timeScale,
           );
 
           cachedCurve = this.#generateCurve(cachedDuration, this.baseDuration, {
@@ -574,7 +574,7 @@ export class CustomEnvelope implements LibNode {
             audioParam.setValueCurveAtTime(
               cachedCurve,
               phase,
-              safeCurveDuration
+              safeCurveDuration,
             );
           } catch (error) {
             // Curve overlap, advance phase
@@ -582,7 +582,7 @@ export class CustomEnvelope implements LibNode {
             if (debugOverlapCount >= 100) {
               console.debug(
                 `Multiple curve overlaps in looping envelope, nr of overlaps: ${debugOverlapCount} 
-                (loop duration: ${cachedDuration.toFixed(3)}s, buffer: ${safetyBuffer})`
+                (loop duration: ${cachedDuration.toFixed(3)}s, buffer: ${safetyBuffer})`,
               );
               debugOverlapCount = 0;
             }
@@ -651,7 +651,7 @@ export class CustomEnvelope implements LibNode {
   // Temp fix for Firefox - fixed release
   #isFirefox = navigator.userAgent.includes('Firefox');
 
-  // ponytail: temporary release-click diagnostic; remove after envGain handoff is fixed.
+  // release-click diagnostic
   #debugRelease(data: {
     audioParamValue: number;
     elapsedSeconds?: number;
@@ -661,7 +661,6 @@ export class CustomEnvelope implements LibNode {
     startTime: number;
     activeStartTime?: number;
   }) {
-    if (this.envelopeType !== 'amp-env') return;
     console.debug('CustomEnvelope release debug:', {
       envelopeType: this.envelopeType,
       ...data,
@@ -678,7 +677,8 @@ export class CustomEnvelope implements LibNode {
       midiNote?: number;
       minValue?: number;
       maxValue?: number;
-    }
+    },
+    debugLog: boolean = false,
   ) {
     if (this.#isReleased) return;
 
@@ -700,7 +700,7 @@ export class CustomEnvelope implements LibNode {
             cancelScheduledParamValues(audioParam, delayedNow);
             audioParam.linearRampToValueAtTime(0, delayedNow + 0.1);
             console.debug(
-              'Firefox delayed release envelope - linear ramp to 0'
+              'Firefox delayed release envelope - linear ramp to 0',
             );
           } catch (delayedError) {
             console.debug('Firefox delayed release also failed:', delayedError);
@@ -716,7 +716,7 @@ export class CustomEnvelope implements LibNode {
           } catch (veryDelayedError) {
             console.debug(
               'Firefox very delayed release failed:',
-              veryDelayedError
+              veryDelayedError,
             );
           }
         }, 50);
@@ -737,7 +737,7 @@ export class CustomEnvelope implements LibNode {
               (this.#syncedToPlaybackRate
                 ? activeEnvelope!.options.playbackRate
                 : 1) *
-              this.#timeScale
+              this.#timeScale,
           )
         : undefined;
     const releaseStartValue =
@@ -746,19 +746,21 @@ export class CustomEnvelope implements LibNode {
       envelopeTime !== undefined
         ? this.#clampToPointValueRange(
             this.#data.interpolateValueAtTime(envelopeTime) *
-              activeEnvelope.options.baseValue
+              activeEnvelope.options.baseValue,
           )
         : undefined;
 
-    this.#debugRelease({
-      audioParamValue: audioParam.value,
-      elapsedSeconds,
-      envelopeTime,
-      releaseStartValue,
-      safeStart,
-      startTime,
-      activeStartTime: activeEnvelope?.startTime,
-    });
+    if (debugLog) {
+      this.#debugRelease({
+        audioParamValue: audioParam.value,
+        elapsedSeconds,
+        envelopeTime,
+        releaseStartValue,
+        safeStart,
+        startTime,
+        activeStartTime: activeEnvelope?.startTime,
+      });
+    }
 
     this.#continueFromPoint(audioParam, startTime, this.releasePointIndex, {
       baseValue: audioParam.value,
@@ -778,7 +780,7 @@ export class CustomEnvelope implements LibNode {
       releaseStartValue?: number;
       voiceId?: string;
       midiNote?: number;
-    }
+    },
   ) {
     const { baseValue = 1 } = options;
 
@@ -792,11 +794,11 @@ export class CustomEnvelope implements LibNode {
       fromPointIndex,
       this.points.length - 1,
       options.playbackRate,
-      this.#timeScale
+      this.#timeScale,
     );
 
     const targetEndValue = this.#clampToPointValueRange(
-      this.#data.interpolateValueAtTime(lastPoint.time)
+      this.#data.interpolateValueAtTime(lastPoint.time),
     );
 
     if (scaledRemainingDuration <= 0.0001) {
@@ -809,7 +811,7 @@ export class CustomEnvelope implements LibNode {
     const sampleRate = this.#getCurveSamplingRate(scaledRemainingDuration);
     const numSamples = Math.max(
       2,
-      Math.floor(scaledRemainingDuration * sampleRate)
+      Math.floor(scaledRemainingDuration * sampleRate),
     );
     const curve = new Float32Array(numSamples);
 
@@ -821,7 +823,7 @@ export class CustomEnvelope implements LibNode {
 
       // Get the envelope's original value at this time
       curve[i] = this.#clampToPointValueRange(
-        this.#data.interpolateValueAtTime(absoluteTime)
+        this.#data.interpolateValueAtTime(absoluteTime),
       );
     }
 
@@ -854,18 +856,22 @@ export class CustomEnvelope implements LibNode {
       audioParam.setValueCurveAtTime(
         adjustedCurve,
         safeStart + 0.001,
-        scaledRemainingDuration
+        scaledRemainingDuration,
       );
     } catch (error) {
       // Silent fallback - this is expected behavior for rapid envelope changes
 
       try {
         // Fallback to simple linear ramp
-        cancelAndPinParamValue(audioParam, safeStart, options.releaseStartValue);
+        cancelAndPinParamValue(
+          audioParam,
+          safeStart,
+          options.releaseStartValue,
+        );
 
         audioParam.linearRampToValueAtTime(
           targetEndValue,
-          safeStart + scaledRemainingDuration
+          safeStart + scaledRemainingDuration,
         );
       } catch (fallbackError) {
         console.warn('Fallback linear ramp also failed:', fallbackError);
@@ -888,11 +894,11 @@ export class CustomEnvelope implements LibNode {
 
   setLoopEnabled = (
     enabled: boolean,
-    mode: 'normal' | 'ping-pong' | 'reverse' = 'normal'
+    mode: 'normal' | 'ping-pong' | 'reverse' = 'normal',
   ) => {
     if (mode !== 'normal') {
       console.info(
-        `Only default env loop mode implemented. Other modes coming soon!`
+        `Only default env loop mode implemented. Other modes coming soon!`,
       );
     }
     this.#loopEnabled = enabled;
@@ -951,19 +957,19 @@ export class CustomEnvelope implements LibNode {
             minValue: audioParam.minValue,
             maxValue: audioParam.maxValue,
             startFromValue: audioParam.value,
-          }
+          },
         );
 
         audioParam.setValueCurveAtTime(
           curve,
           currentTime,
-          scaledRemainingDuration
+          scaledRemainingDuration,
         );
       }
     } catch (error) {
       // Silent fallback for rapid changes
       console.debug(
-        'Dynamic sustain reschedule failed, envelope will continue normally'
+        'Dynamic sustain reschedule failed, envelope will continue normally',
       );
     }
   }
@@ -1042,7 +1048,7 @@ export class CustomEnvelope implements LibNode {
   hasVariation(): boolean {
     const firstValue = this.points[0]?.value ?? 0;
     return this.points.some(
-      (point) => Math.abs(point.value - firstValue) > 0.001
+      (point) => Math.abs(point.value - firstValue) > 0.001,
     );
   }
 

--- a/packages/audiolib/src/nodes/params/envelopes/CustomEnvelope.ts
+++ b/packages/audiolib/src/nodes/params/envelopes/CustomEnvelope.ts
@@ -645,6 +645,23 @@ export class CustomEnvelope implements LibNode {
   // Temp fix for Firefox - fixed release
   #isFirefox = navigator.userAgent.includes('Firefox');
 
+  // ponytail: temporary release-click diagnostic; remove after envGain handoff is fixed.
+  #debugRelease(data: {
+    audioParamValue: number;
+    elapsedSeconds?: number;
+    envelopeTime?: number;
+    releaseStartValue?: number;
+    safeStart: number;
+    startTime: number;
+    activeStartTime?: number;
+  }) {
+    if (this.envelopeType !== 'amp-env') return;
+    console.debug('CustomEnvelope release debug:', {
+      envelopeType: this.envelopeType,
+      ...data,
+    });
+  }
+
   releaseEnvelope(
     audioParam: AudioParam,
     startTime: number,
@@ -659,6 +676,7 @@ export class CustomEnvelope implements LibNode {
   ) {
     if (this.#isReleased) return;
 
+    const activeEnvelope = this.#activeEnvelope;
     this.#isReleased = true;
     this.#activeEnvelope = null; // Clear active envelope state
 
@@ -701,9 +719,45 @@ export class CustomEnvelope implements LibNode {
       return; // Don't call #continueFromPoint if using fallback
     }
 
+    const safeStart = Math.max(this.#context.currentTime, startTime);
+    const elapsedSeconds = activeEnvelope
+      ? Math.max(0, safeStart - activeEnvelope.startTime)
+      : undefined;
+    const envelopeTime =
+      elapsedSeconds !== undefined
+        ? Math.min(
+            this.baseDuration,
+            elapsedSeconds *
+              (this.#syncedToPlaybackRate
+                ? activeEnvelope!.options.playbackRate
+                : 1) *
+              this.#timeScale
+          )
+        : undefined;
+    const releaseStartValue =
+      this.envelopeType === 'amp-env' &&
+      activeEnvelope?.audioParam === audioParam &&
+      envelopeTime !== undefined
+        ? this.#clampToPointValueRange(
+            this.#data.interpolateValueAtTime(envelopeTime) *
+              activeEnvelope.options.baseValue
+          )
+        : undefined;
+
+    this.#debugRelease({
+      audioParamValue: audioParam.value,
+      elapsedSeconds,
+      envelopeTime,
+      releaseStartValue,
+      safeStart,
+      startTime,
+      activeStartTime: activeEnvelope?.startTime,
+    });
+
     this.#continueFromPoint(audioParam, startTime, this.releasePointIndex, {
       baseValue: audioParam.value,
       playbackRate: this.#currentPlaybackRate,
+      releaseStartValue,
       ...options,
     });
   }
@@ -715,6 +769,7 @@ export class CustomEnvelope implements LibNode {
     options: {
       baseValue: number;
       playbackRate: number;
+      releaseStartValue?: number;
       voiceId?: string;
       midiNote?: number;
     }
@@ -777,7 +832,7 @@ export class CustomEnvelope implements LibNode {
     try {
       // ! Needs testing specifically for Firefox ( and Safari )
       cancelScheduledParamValues(audioParam, safeStart);
-      const currentValue = audioParam.value;
+      const currentValue = options.releaseStartValue ?? audioParam.value;
 
       // Adjust curve to start from currentValue instead of envelope's release point
       const adjustedCurve = new Float32Array(curve.length);
@@ -786,10 +841,12 @@ export class CustomEnvelope implements LibNode {
         // Blend from current value to target curve value
         adjustedCurve[i] = currentValue + progress * (curve[i] - currentValue);
       }
+      adjustedCurve[0] = currentValue;
 
+      audioParam.setValueAtTime(currentValue, safeStart);
       audioParam.setValueCurveAtTime(
         adjustedCurve,
-        safeStart,
+        safeStart + 0.001,
         scaledRemainingDuration
       );
     } catch (error) {

--- a/packages/audiolib/src/nodes/params/envelopes/CustomEnvelope.ts
+++ b/packages/audiolib/src/nodes/params/envelopes/CustomEnvelope.ts
@@ -766,6 +766,13 @@ export class CustomEnvelope implements LibNode {
       baseValue: audioParam.value,
       playbackRate: this.#currentPlaybackRate,
       releaseStartValue,
+      // Amp release curve must be scaled like releaseStartValue (velocity),
+      // otherwise it drifts toward the unscaled trajectory. Other envelope
+      // types map baseValue differently, so leave them unscaled.
+      curveScale:
+        this.envelopeType === 'amp-env'
+          ? activeEnvelope?.options.baseValue
+          : undefined,
       ...options,
     });
   }
@@ -778,11 +785,12 @@ export class CustomEnvelope implements LibNode {
       baseValue: number;
       playbackRate: number;
       releaseStartValue?: number;
+      curveScale?: number;
       voiceId?: string;
       midiNote?: number;
     },
   ) {
-    const { baseValue = 1 } = options;
+    const curveScale = options.curveScale ?? 1;
 
     const fromPoint = this.points[fromPointIndex];
     const lastPoint = this.points[this.points.length - 1];
@@ -798,7 +806,7 @@ export class CustomEnvelope implements LibNode {
     );
 
     const targetEndValue = this.#clampToPointValueRange(
-      this.#data.interpolateValueAtTime(lastPoint.time),
+      this.#data.interpolateValueAtTime(lastPoint.time) * curveScale,
     );
 
     if (scaledRemainingDuration <= 0.0001) {
@@ -823,7 +831,7 @@ export class CustomEnvelope implements LibNode {
 
       // Get the envelope's original value at this time
       curve[i] = this.#clampToPointValueRange(
-        this.#data.interpolateValueAtTime(absoluteTime),
+        this.#data.interpolateValueAtTime(absoluteTime) * curveScale,
       );
     }
 

--- a/packages/audiolib/src/nodes/params/envelopes/CustomEnvelope.ts
+++ b/packages/audiolib/src/nodes/params/envelopes/CustomEnvelope.ts
@@ -734,14 +734,17 @@ export class CustomEnvelope implements LibNode {
       this.#timeScale
     );
 
-    // Return early if duration is too small to be meaningful for audio scheduling
-    if (scaledRemainingDuration <= 0.0001) return;
-
-    const currentValue = audioParam.value;
-
     const targetEndValue = this.#clampToPointValueRange(
       this.#data.interpolateValueAtTime(lastPoint.time)
     );
+
+    if (scaledRemainingDuration <= 0.0001) {
+      cancelScheduledParamValues(audioParam, safeStart);
+      audioParam.linearRampToValueAtTime(targetEndValue, safeStart + 0.005);
+      return;
+    }
+
+    const currentValue = audioParam.value;
 
     // Generate the release curve shape from sustain point to end
     const sampleRate = this.#getCurveSamplingRate(scaledRemainingDuration);

--- a/packages/audiolib/src/nodes/params/envelopes/CustomEnvelope.ts
+++ b/packages/audiolib/src/nodes/params/envelopes/CustomEnvelope.ts
@@ -744,8 +744,6 @@ export class CustomEnvelope implements LibNode {
       return;
     }
 
-    const currentValue = audioParam.value;
-
     // Generate the release curve shape from sustain point to end
     const sampleRate = this.#getCurveSamplingRate(scaledRemainingDuration);
     const numSamples = Math.max(
@@ -779,6 +777,7 @@ export class CustomEnvelope implements LibNode {
     try {
       // ! Needs testing specifically for Firefox ( and Safari )
       cancelScheduledParamValues(audioParam, safeStart);
+      const currentValue = audioParam.value;
 
       // Adjust curve to start from currentValue instead of envelope's release point
       const adjustedCurve = new Float32Array(curve.length);

--- a/packages/audiolib/src/nodes/params/envelopes/CustomEnvelope.ts
+++ b/packages/audiolib/src/nodes/params/envelopes/CustomEnvelope.ts
@@ -11,7 +11,13 @@ import {
 import { EnvelopePoint, EnvelopeType } from './env-types';
 import { EnvelopeData } from './EnvelopeData';
 import { LibNode } from '@/nodes/LibNode';
-import { assert, cancelScheduledParamValues, clamp, mapToRange } from '@/utils';
+import {
+  assert,
+  cancelAndPinParamValue,
+  cancelScheduledParamValues,
+  clamp,
+  mapToRange,
+} from '@/utils';
 
 // ===== CUSTOM ENVELOPE  =====
 export class CustomEnvelope implements LibNode {
@@ -794,7 +800,7 @@ export class CustomEnvelope implements LibNode {
     );
 
     if (scaledRemainingDuration <= 0.0001) {
-      cancelScheduledParamValues(audioParam, safeStart);
+      cancelAndPinParamValue(audioParam, safeStart, options.releaseStartValue);
       audioParam.linearRampToValueAtTime(targetEndValue, safeStart + 0.005);
       return;
     }
@@ -831,8 +837,10 @@ export class CustomEnvelope implements LibNode {
 
     try {
       // ! Needs testing specifically for Firefox ( and Safari )
-      cancelScheduledParamValues(audioParam, safeStart);
+      // Capture the handoff value BEFORE cancelling: cancel reverts
+      // audioParam.value to its pre-curve value (0 for amp env).
       const currentValue = options.releaseStartValue ?? audioParam.value;
+      cancelAndPinParamValue(audioParam, safeStart, currentValue);
 
       // Adjust curve to start from currentValue instead of envelope's release point
       const adjustedCurve = new Float32Array(curve.length);
@@ -843,7 +851,6 @@ export class CustomEnvelope implements LibNode {
       }
       adjustedCurve[0] = currentValue;
 
-      audioParam.setValueAtTime(currentValue, safeStart);
       audioParam.setValueCurveAtTime(
         adjustedCurve,
         safeStart + 0.001,
@@ -854,7 +861,7 @@ export class CustomEnvelope implements LibNode {
 
       try {
         // Fallback to simple linear ramp
-        cancelScheduledParamValues(audioParam, safeStart);
+        cancelAndPinParamValue(audioParam, safeStart, options.releaseStartValue);
 
         audioParam.linearRampToValueAtTime(
           targetEndValue,

--- a/packages/audiolib/src/utils/validate/audioparam.ts
+++ b/packages/audiolib/src/utils/validate/audioparam.ts
@@ -1,5 +1,25 @@
 import { isCancelAndHoldSupported } from './environment';
 
+/**
+ * Chromium workaround: cancelAndHoldAtTime on a partially-rendered
+ * setValueCurveAtTime replays the curve from index 0 for one render quantum
+ * (param dips to the curve start value -> audible click). Instead, cancel
+ * everything and pin the param at a known value.
+ *
+ * holdValue must be captured BEFORE cancelScheduledValues runs, because
+ * cancelling reverts param.value to its pre-curve value. Pass holdValue
+ * explicitly whenever the caller knows the intended value.
+ */
+export function cancelAndPinParamValue(
+  param: AudioParam,
+  timestamp: number,
+  holdValue?: number
+) {
+  const value = holdValue ?? param.value; // read before cancel
+  param.cancelScheduledValues(timestamp);
+  param.setValueAtTime(value, timestamp);
+}
+
 export function cancelScheduledParamValues(
   param: AudioParam | AudioParam[],
   timestamp: number,

--- a/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
+++ b/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
@@ -189,6 +189,7 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
       case 'voice:start':
         this.isReleasing = false;
         this.isPlaying = true;
+        this.releaseDebugPending = false;
         this.loopCount = 0;
 
         // will be set in process() using parameters
@@ -202,6 +203,7 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
 
       case 'voice:release':
         this.isReleasing = true;
+        this.releaseDebugPending = true;
 
         this.port.postMessage({
           type: 'voice:releasing',
@@ -255,6 +257,7 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
   #resetState() {
     this.isPlaying = false;
     this.isReleasing = false;
+    this.releaseDebugPending = false;
     this.loopEnabled = false;
     this.transpositionPlaybackrate = 1;
     this.velocitySensitivity = 1.0; // full velocity = unity gain
@@ -771,6 +774,19 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
         sample,
         isConstant.envGain
       );
+      if (this.releaseDebugPending) {
+        this.releaseDebugPending = false;
+        this.port.postMessage({
+          type: 'debug:release',
+          currentTime,
+          playbackPosition: this.playbackPosition,
+          envGainFirst: parameters.envGain[0],
+          envGainLast: parameters.envGain[parameters.envGain.length - 1],
+          rawSample: this.buffer?.[0]?.[Math.floor(this.playbackPosition)] || 0,
+          loopEnabled: this.loopEnabled,
+          loopCount: this.loopCount,
+        });
+      }
 
       const baseRate = this.#getSafeParam(
         parameters.playbackRate,

--- a/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
+++ b/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
@@ -175,7 +175,7 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
 
       case 'voice:setZeroCrossings':
         this.zeroCrossings = (zeroCrossings || []).map(
-          (timeSec) => timeSec * sampleRate
+          (timeSec) => timeSec * sampleRate,
         );
 
         // Set min/max zero crossings for parameter constraints
@@ -189,7 +189,6 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
       case 'voice:start':
         this.isReleasing = false;
         this.isPlaying = true;
-        this.releaseDebugPending = false;
         this.loopCount = 0;
 
         // will be set in process() using parameters
@@ -203,7 +202,6 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
 
       case 'voice:release':
         this.isReleasing = true;
-        this.releaseDebugPending = true;
 
         this.port.postMessage({
           type: 'voice:releasing',
@@ -257,7 +255,6 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
   #resetState() {
     this.isPlaying = false;
     this.isReleasing = false;
-    this.releaseDebugPending = false;
     this.loopEnabled = false;
     this.transpositionPlaybackrate = 1;
     this.velocitySensitivity = 1.0; // full velocity = unity gain
@@ -473,7 +470,7 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
     playbackRange,
     driftAmount = 0,
     tempo = 120,
-    playbackRate = 1
+    playbackRate = 1,
   ) {
     const lpStart = params.loopStartSamples;
     const lpEnd = params.loopEndSamples;
@@ -494,7 +491,7 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
       const quantizedDuration = this.#quantizeLoopDuration(
         baseDuration,
         tempo,
-        playbackRate
+        playbackRate,
       );
       calcLoopEnd = calcLoopStart + quantizedDuration;
 
@@ -517,7 +514,7 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
           baseDuration <= this.PITCH_PRESERVATION_THRESHOLD
             ? Math.max(
                 1,
-                Math.floor(this.PITCH_PRESERVATION_THRESHOLD / baseDuration)
+                Math.floor(this.PITCH_PRESERVATION_THRESHOLD / baseDuration),
               )
             : 1;
 
@@ -527,7 +524,7 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
         if (shouldUpdateDrift) {
           this.currentLoopDrift = this.#generateLoopDrift(
             driftAmount,
-            baseDuration
+            baseDuration,
           );
 
           if (this.panDriftEnabled && driftAmount > 0 && this.loopCount > 0) {
@@ -549,7 +546,7 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
       const minLoopDuration = Math.max(1, Math.floor(baseDuration * 0.1)); // At least 10% of original duration
       calcLoopEnd = Math.max(
         calcLoopStart + minLoopDuration,
-        Math.min(playbackRange.endSamples, driftedLoopEnd)
+        Math.min(playbackRange.endSamples, driftedLoopEnd),
       );
     } else {
       // Ensure pan drift is set to zero if no loopDrift applied
@@ -573,7 +570,7 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
 
   #getConstantFlags(parameters) {
     return Object.fromEntries(
-      Object.keys(parameters).map((key) => [key, parameters[key].length === 1])
+      Object.keys(parameters).map((key) => [key, parameters[key].length === 1]),
     );
   }
 
@@ -713,13 +710,13 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
       playbackRange,
       parameters.loopDurationDriftAmount[0],
       tempo,
-      basePlaybackRate
+      basePlaybackRate,
     );
 
     // Calculate amplitude compensation for short loops
     const amplitudeGain = this.#analyzeLoopAmplitude(
       loopRange.loopStartSamples,
-      loopRange.loopEndSamples
+      loopRange.loopEndSamples,
     );
 
     const velocityGain =
@@ -772,26 +769,13 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
       const envelopeGain = this.#getSafeParam(
         parameters.envGain,
         sample,
-        isConstant.envGain
+        isConstant.envGain,
       );
-      if (this.releaseDebugPending) {
-        this.releaseDebugPending = false;
-        this.port.postMessage({
-          type: 'debug:release',
-          currentTime,
-          playbackPosition: this.playbackPosition,
-          envGainFirst: parameters.envGain[0],
-          envGainLast: parameters.envGain[parameters.envGain.length - 1],
-          rawSample: this.buffer?.[0]?.[Math.floor(this.playbackPosition)] || 0,
-          loopEnabled: this.loopEnabled,
-          loopCount: this.loopCount,
-        });
-      }
 
       const baseRate = this.#getSafeParam(
         parameters.playbackRate,
         sample,
-        isConstant.playbackRate
+        isConstant.playbackRate,
       );
 
       const effectiveRate = this.reversePlayback
@@ -869,13 +853,13 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
       if (this.reversePlayback) {
         nextPosition = Math.max(
           currentPosition - 1,
-          playbackRange.startSamples
+          playbackRange.startSamples,
         );
         interpWeight = 1 - positionOffset; // Reverse: weight toward previous sample
       } else {
         nextPosition = Math.min(
           currentPosition + 1,
-          playbackRange.endSamples - 1
+          playbackRange.endSamples - 1,
         );
         interpWeight = positionOffset; // Forward: weight toward next sample
       }
@@ -886,7 +870,7 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
         if (!outputChannels[channel]) {
           console.warn(
             `Output channel ${channel} does not exist. Available channels:`,
-            outputChannels.length
+            outputChannels.length,
           );
           continue;
         }
@@ -939,7 +923,7 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
         // Basic hard limiting
         outputChannels[channel][sample] = Math.max(
           -1,
-          Math.min(1, isFinite(panAdjustedSample) ? panAdjustedSample : 0)
+          Math.min(1, isFinite(panAdjustedSample) ? panAdjustedSample : 0),
         );
       }
 
@@ -949,7 +933,7 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
     // Send position updates if requested
     if (this.usePlaybackPosition) {
       const normalizedPosition = this.#samplesToNormalized(
-        this.playbackPosition
+        this.playbackPosition,
       );
       this.port.postMessage({
         type: 'voice:position',

--- a/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
+++ b/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
@@ -569,9 +569,15 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
   }
 
   #getConstantFlags(parameters) {
-    return Object.fromEntries(
-      Object.keys(parameters).map((key) => [key, parameters[key].length === 1]),
-    );
+    this.constantFlags ??= {
+      envGain: true,
+      playbackRate: true,
+    };
+
+    this.constantFlags.envGain = parameters.envGain.length === 1;
+    this.constantFlags.playbackRate = parameters.playbackRate.length === 1;
+
+    return this.constantFlags;
   }
 
   /**


### PR DESCRIPTION
## Summary

Draft PR to preserve the current release-click investigation state.

This branch does not claim the issue is fully fixed. It captures the defensive changes and diagnostics added while tracing an audible click when releasing short notes in `SamplePlayer`.

## What we discovered

- The click is reproducible from `apps/play`, but the strongest evidence points below the app layer in the amp-envelope/audio-param handoff.
- Worklet release snapshots showed suspicious first release blocks such as:
  - `envGainFirst: 0`, `envGainLast: ~0.25-0.32`
  - large nonzero `rawSample` values in the same block
- That means release sometimes starts with a gain discontinuity: silence at the start of the render quantum, then a nonzero release gain by the end.
- The click is more noticeable on very short notes, likely because release interrupts an active/steep attack curve.
- A processor-side forced release fade reduced symptoms but broke envelope behavior by making all notes fade out quickly regardless of configured release duration, so it was reverted.

## Issues eliminated so far

- A hard worklet `voice:stop` click was unlikely to be the primary culprit; adding a 5ms stop de-click fade did not fix the release click.
- Tiny/zero release segments were not the primary culprit; adding a fallback fade for very short release durations did not fix it.
- Reading `audioParam.value` before `cancelAndHoldAtTime()` was not sufficient; moving the read after the hold did not fix it.
- Feedback bus release behavior was not the culprit; a note-off feedback release probe did not fix the click and was reverted as a sound-design change.
- A processor-side release fade is not acceptable as a fix because it bypasses the intended envelope release duration.

## Changes in this branch

- `SampleVoice.stop()` now ramps `envGain` to zero over 5ms before sending `voice:stop`.
- `CustomEnvelope` now uses a 5ms fallback ramp instead of doing nothing when the release segment is too short to schedule meaningfully.
- `CustomEnvelope` now reads release curve start after cancelling/holding prior automation.
- `CustomEnvelope` now estimates an `amp-env` release start value from the active envelope timeline and pins that value before scheduling the release curve.
- Temporary debug logging was added:
  - `CustomEnvelope release debug`
  - `SampleVoice release debug`

## Needs review before keeping

- Verify the 5ms `SampleVoice.stop()` de-click fade is beneficial and does not introduce unwanted delayed voice cleanup.
- Verify the tiny-release fallback fade is musically acceptable and not masking a deeper release-shape issue.
- Review the amp-env-only release-start estimate. It is intentionally scoped to `amp-env` because the observed discontinuity is `envGain`; do not generalize it to pitch/filter envelopes without evidence.
- Remove or gate the temporary debug logs once the handoff issue is understood.

## Current next step

Use the new debug logs to compare:

- `CustomEnvelope release debug.releaseStartValue`
- `CustomEnvelope release debug.envelopeTime`
- `SampleVoice release debug.envGainFirst`
- `SampleVoice release debug.envGainLast`

The next likely fix should target why short-note releases still sometimes produce `envGainFirst: 0` while `envGainLast` is nonzero.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced audible clicks when stopping samples and releasing envelopes.
  * Improved playback accuracy during looping and tempo-based playback, especially with changing playback speed.
  * Made parameter transitions smoother by preserving values during rapid automation changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->