### PR TITLE
Add audio input device selection

### DIFF
--- a/apps/play/src/App.tsx
+++ b/apps/play/src/App.tsx
@@ -79,9 +79,15 @@ const App: Component = () => {
 
       setCurrentAudioBuffer(audiobuffer);
       setSampleLoaded(true);
-      setSelectedInputDeviceId(
-        samplePlayerRef?.getRecorderInputDeviceId() || '',
-      );
+      // Preserve a device chosen before the player was ready
+      const chosenDeviceId = selectedInputDeviceId();
+      if (chosenDeviceId) {
+        samplePlayerRef?.setRecorderInputDeviceId(chosenDeviceId);
+      } else {
+        setSelectedInputDeviceId(
+          samplePlayerRef?.getRecorderInputDeviceId() || '',
+        );
+      }
     };
 
     const updateLayout = () => {

--- a/apps/play/src/App.tsx
+++ b/apps/play/src/App.tsx
@@ -1,5 +1,11 @@
 // src/App.tsx
-import { Component, onMount, createSignal, onCleanup } from 'solid-js';
+import {
+  Component,
+  onMount,
+  createSignal,
+  createMemo,
+  onCleanup,
+} from 'solid-js';
 
 import type { SamplerElement, SamplePlayer } from '@repo/audio-components';
 // import { KnobComponent, type KnobChangeEventDetail, Oscilloscope } from '@repo/audio-components/solidjs';
@@ -24,6 +30,7 @@ import SampleListSection from './components/SampleListSection';
 import BaseButton from './components/Button';
 import RowCollapseIcons from './components/RowCollapseIcons';
 import OutputDeviceSelect from './components/OutputDeviceSelect';
+import InputDeviceSelect from './components/InputDeviceSelect';
 
 const App: Component = () => {
   const [layout, setLayout] = createSignal<LayoutType>('desktop');
@@ -41,10 +48,25 @@ const App: Component = () => {
     'samples',
   );
 
+  let inputSourceSelectRef: HTMLElement | undefined;
+  const [inputSource, setInputSource] = createSignal('audio-input');
+  const inputDeviceSelectDisabled = createMemo(
+    () => inputSource() !== 'audio-input',
+  );
+
+  const [selectedInputDeviceId, setSelectedInputDeviceId] = createSignal('');
+  const handleInputDeviceChange = (deviceId: string) => {
+    getSamplePlayer()?.setRecorderInputDeviceId(deviceId);
+    setSelectedInputDeviceId(deviceId);
+  };
+
   const { handleSampleSelect } = useSampleSelection(
     () => samplePlayerRef,
     setSidebarOpen,
   );
+
+  const getSamplePlayer = () =>
+    samplePlayerRef || samplerElementRef?.getSamplePlayer?.() || null;
 
   onMount(() => {
     const handleSampleLoaded = () => {
@@ -57,6 +79,9 @@ const App: Component = () => {
 
       setCurrentAudioBuffer(audiobuffer);
       setSampleLoaded(true);
+      setSelectedInputDeviceId(
+        samplePlayerRef?.getRecorderInputDeviceId() || '',
+      );
     };
 
     const updateLayout = () => {
@@ -74,6 +99,15 @@ const App: Component = () => {
     addExpandCollapseListeners();
     addPreventScrollOnSpacebarListener();
     window.addEventListener('resize', updateLayout);
+
+    const inputSourceSelect = inputSourceSelectRef?.querySelector('select');
+    setInputSource(inputSourceSelect?.value ?? 'audio-input');
+    const handleInputSourceChange = (e: Event) =>
+      setInputSource((e.target as HTMLSelectElement).value);
+    inputSourceSelect?.addEventListener('change', handleInputSourceChange);
+    onCleanup(() =>
+      inputSourceSelect?.removeEventListener('change', handleInputSourceChange),
+    );
 
     document.addEventListener('sample-loaded', handleSampleLoaded);
 
@@ -185,6 +219,13 @@ const App: Component = () => {
               defaultTheme='light'
             />
 
+            <InputDeviceSelect
+              class={`toolbar-btn input-device-select ${toolbarOpen() ? '__toolbar-open' : ''}`}
+              disabled={inputDeviceSelectDisabled()}
+              value={selectedInputDeviceId()}
+              onChange={handleInputDeviceChange}
+            />
+
             <OutputDeviceSelect
               class={`toolbar-btn output-device-select ${toolbarOpen() ? '__toolbar-open' : ''}`}
             />
@@ -266,7 +307,19 @@ const App: Component = () => {
                   target-node-id='test-sampler'
                   show-status='false'
                 />
-                <input-select target-node-id='test-sampler' />
+                <div class='input-source-selection-container'>
+                  <input-select
+                    ref={inputSourceSelectRef}
+                    target-node-id='test-sampler'
+                    class='input-source-select'
+                  />
+                  <InputDeviceSelect
+                    class='input-device-select'
+                    disabled={inputDeviceSelectDisabled()}
+                    value={selectedInputDeviceId()}
+                    onChange={handleInputDeviceChange}
+                  />
+                </div>
               </div>
               <load-button target-node-id='test-sampler' show-status='false' />
 

--- a/apps/play/src/components/InputDeviceSelect.tsx
+++ b/apps/play/src/components/InputDeviceSelect.tsx
@@ -1,0 +1,98 @@
+// components/InputDeviceSelect.tsx
+import {
+  Component,
+  For,
+  createMemo,
+  createSignal,
+  onCleanup,
+  onMount,
+} from 'solid-js';
+import { getAudioInputDevices } from '@repo/audiolib';
+
+interface InputDeviceSelectProps {
+  class?: string;
+  disabled?: boolean;
+  value: string;
+  onChange: (deviceId: string) => void;
+}
+
+/** Chooses the audio input device used for future sampler recordings. Controlled component - device id lives in the parent so multiple instances stay in sync. */
+const InputDeviceSelect: Component<InputDeviceSelectProps> = (props) => {
+  const [devices, setDevices] = createSignal<MediaDeviceInfo[]>([]);
+
+  const refresh = async () => setDevices(await getAudioInputDevices());
+
+  const refreshWithPermission = async () => {
+    await refresh();
+    const gated = devices().every((d) => !d.label);
+    if (!gated) return;
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      stream.getTracks().forEach((t) => t.stop());
+      await refresh();
+    } catch {
+      // permission denied - keep the unlabeled list
+    }
+  };
+
+  onMount(() => {
+    refresh();
+    navigator.mediaDevices.addEventListener('devicechange', refresh);
+    onCleanup(() =>
+      navigator.mediaDevices.removeEventListener('devicechange', refresh),
+    );
+  });
+
+  const selectedLabel = createMemo(() => {
+    if (!props.value) return 'System Default Input';
+    return (
+      devices().find((d) => d.deviceId === props.value)?.label ||
+      'Audio input device'
+    );
+  });
+
+  const onChange = (deviceId: string) =>
+    props.onChange(deviceId === 'default' ? '' : deviceId);
+
+  return (
+    <select
+      aria-label='Audio input device'
+      title={selectedLabel()}
+      class={props.class}
+      value={props.value}
+      disabled={props.disabled}
+      onfocus={refreshWithPermission}
+      onchange={(e) => onChange(e.currentTarget.value)}
+    >
+      <button type='button'>
+        <svg
+          aria-hidden='true'
+          viewBox='0 0 24 24'
+          width='20'
+          height='20'
+          fill='none'
+          stroke='currentColor'
+          stroke-width='2'
+          stroke-linecap='round'
+          stroke-linejoin='round'
+        >
+          <path d='M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z' />
+          <path d='M19 10v2a7 7 0 0 1-14 0v-2' />
+          <path d='M12 19v3' />
+        </svg>
+      </button>
+      <option value='' selected={!props.value}>
+        System Default Input
+      </option>
+      <For each={devices().filter((d) => d.deviceId !== 'default')}>
+        {(d, i) => (
+          <option value={d.deviceId} selected={props.value === d.deviceId}>
+            {d.label || `Input ${i() + 1}`}
+          </option>
+        )}
+      </For>
+    </select>
+  );
+};
+
+export default InputDeviceSelect;

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -652,6 +652,39 @@ piano-keyboard.visible {
   border: 1px solid #aaa;
 }
 
+.input-device-select {
+  appearance: base-select;
+  max-width: 36px;
+  white-space: nowrap;
+  color: white;
+}
+
+.input-device-select:disabled {
+  color: gray;
+}
+
+.input-source-selection-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  width: 100px;
+  overflow-x: visible;
+
+  /* > .input-source-select {
+    max-width: 50px;
+  } */
+  /* > .input-device-select {
+    outline: lime 2px solid;
+  }*/
+}
+
+.ac-select {
+  /* -webkit-appearance: auto;
+  appearance: auto; */
+  font-size: 12px;
+}
+
 /* SAMPLELIB SIDEBAR */
 
 .toolbar-wrapper {
@@ -736,6 +769,10 @@ piano-keyboard.visible {
   &:active {
     transform: scale(0.9);
   }
+
+  &:disabled {
+    color: gray;
+  }
 }
 
 .toolbar-wrapper > .expandable-width > .toolbar-btn {
@@ -757,7 +794,8 @@ piano-keyboard.visible {
   }
 }
 
-.toolbar-wrapper > .expandable-width > .output-device-select {
+.toolbar-wrapper > .expandable-width > .output-device-select,
+.input-device-select {
   appearance: base-select;
   max-width: 36px;
   white-space: nowrap;

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -671,12 +671,6 @@ piano-keyboard.visible {
   width: 100px;
   overflow-x: visible;
 
-  /* > .input-source-select {
-    max-width: 50px;
-  } */
-  /* > .input-device-select {
-    outline: lime 2px solid;
-  }*/
 }
 
 .ac-select {

--- a/packages/audio-components/src/elements/Sampler/components/SamplerButtonFactory.ts
+++ b/packages/audio-components/src/elements/Sampler/components/SamplerButtonFactory.ts
@@ -64,7 +64,7 @@ export const UploadButton = (attributes: ElementProps) => {
   return div(
     { style: COMPONENT_STYLE },
     uploadButton,
-    ...(showStatus.val === 'true' ? [div(() => status.val)] : [])
+    ...(showStatus.val === 'true' ? [div(() => status.val)] : []),
   );
 };
 
@@ -108,7 +108,8 @@ export const RecordButton = (attributes: ElementProps) => {
         return;
       }
 
-      recorderResult.setInputSource(inputSource ?? 'microphone');
+      recorderResult.setInputSource(inputSource ?? 'audio-input');
+      recorderResult.setInputDeviceId(sampler.getRecorderInputDeviceId());
 
       if (inputSource === 'resample') {
         recorderResult.connectResampleInputSource(sampler);
@@ -190,14 +191,14 @@ export const RecordButton = (attributes: ElementProps) => {
     'Record Sample',
     ['record_inactive', 'record_armed', 'record_recording'],
     {
-      size: 'md',
+      size: 'lg',
       onClick: handleClick,
       colors: {
         record_inactive: '#FFFFFF',
         record_armed: '#f59e0b',
         record_recording: '#ef4444',
       },
-    }
+    },
   );
 
   van.derive(() => {
@@ -224,6 +225,6 @@ export const RecordButton = (attributes: ElementProps) => {
   return div(
     { style: COMPONENT_STYLE },
     recordButton,
-    ...(showStatus.val === 'true' ? [div(() => status.val)] : [])
+    ...(showStatus.val === 'true' ? [div(() => status.val)] : []),
   );
 };

--- a/packages/audio-components/src/elements/Sampler/components/SamplerSelectFactory.ts
+++ b/packages/audio-components/src/elements/Sampler/components/SamplerSelectFactory.ts
@@ -37,7 +37,7 @@ export interface SelectConfig<T extends string = string> {
     target: any,
     state: State<T>,
     van: any,
-    targetNodeId: string
+    targetNodeId: string,
   ) => void;
 }
 
@@ -58,7 +58,7 @@ const keymapSelectConfig: SelectConfig<keyof typeof KeyMaps> = {
     sampler: any,
     state: State<keyof typeof KeyMaps>,
     van: any,
-    targetNodeId: string
+    targetNodeId: string,
   ) => {
     van.derive(() => {
       const selectedKeymap = state.val;
@@ -72,7 +72,7 @@ const keymapSelectConfig: SelectConfig<keyof typeof KeyMaps> = {
             selectedValue: state.val,
             targetNodeId: targetNodeId,
           },
-        })
+        }),
       );
     });
   },
@@ -114,7 +114,7 @@ const waveformSelectConfig: SelectConfig<SupportedWaveform> = {
     sampler: any,
     state: State<SupportedWaveform>,
     van: any,
-    targetNodeId: string
+    targetNodeId: string,
   ) => {
     // Set up reactive binding to sampler method
     van.derive(() => {
@@ -151,7 +151,7 @@ const rootNoteSelectConfig: SelectConfig<RootNote> = {
     sampler: any,
     state: State<RootNote>,
     van: any,
-    targetNodeId: string
+    targetNodeId: string,
   ) => {
     van.derive(() => {
       const safeRoot = ROOT_NOTES.includes(state.val)
@@ -165,21 +165,21 @@ const rootNoteSelectConfig: SelectConfig<RootNote> = {
             rootNote: safeRoot,
             targetNodeId: targetNodeId,
           },
-        })
+        }),
       );
     });
   },
 };
 
 const inputSourceSelectConfig: SelectConfig<
-  'microphone' | 'browser' | 'resample'
+  'audio-input' | 'browser' | 'resample'
 > = {
   title: 'Select Audio Input Source',
-  defaultValue: 'microphone',
+  defaultValue: 'audio-input',
   options: [
     {
-      value: 'microphone',
-      label: 'Mic',
+      value: 'audio-input',
+      label: 'Device',
     },
     {
       value: 'browser',
@@ -192,9 +192,9 @@ const inputSourceSelectConfig: SelectConfig<
   ],
   onTargetConnect: (
     sampler: any,
-    state: State<'microphone' | 'browser' | 'resample'>,
+    state: State<'audio-input' | 'browser' | 'resample'>,
     van: any,
-    targetNodeId: string
+    targetNodeId: string,
   ) => {
     van.derive(() => {
       sampler.setRecorderInputSource(state.val);
@@ -209,7 +209,7 @@ const createSamplerSelect = <T extends string = string>(
   getSamplerFn: (nodeId: string) => any,
   van: any,
   componentStyle: string,
-  autoResize = true
+  autoResize = true,
 ) => {
   return (attributes: ElementProps) => {
     const targetNodeId: State<string> = attributes.attr('target-node-id', '');
@@ -230,11 +230,11 @@ const createSamplerSelect = <T extends string = string>(
           } catch (error) {
             console.error(
               `Failed to connect select "${config.label || 'unnamed'}":`,
-              error
+              error,
             );
           }
         }
-      }
+      },
     );
 
     attributes.mount(createMountHandler(attributes));
@@ -271,27 +271,27 @@ const createSamplerSelect = <T extends string = string>(
                     ? 'selected-option-label'
                     : 'option-label',
               },
-              opt.label && opt.label
-            )
-          )
-        )
+              opt.label && opt.label,
+            ),
+          ),
+        ),
       ),
       autoResize &&
         span({
           class: 'ac-select-measure',
           style:
             'visibility: hidden; position: absolute; white-space: pre; font: inherit;',
-        })
+        }),
     );
 
     if (autoResize) {
       setTimeout(() => {
         const container = SelectElement as HTMLElement;
         const select = container.querySelector(
-          '.ac-autoResizableSelect'
+          '.ac-autoResizableSelect',
         ) as HTMLSelectElement | null;
         const measure = container.querySelector(
-          '.ac-select-measure'
+          '.ac-select-measure',
         ) as HTMLSpanElement | null;
 
         const resizeSelect = () => {
@@ -303,7 +303,7 @@ const createSamplerSelect = <T extends string = string>(
           let svgWidth = 0;
           const selectedOption = select.options[select.selectedIndex];
           const optConfig = config.options.find(
-            (opt) => opt.value === selectedOption.value
+            (opt) => opt.value === selectedOption.value,
           );
           if (optConfig && optConfig.svg) {
             const svgEls = container.querySelectorAll('svg');
@@ -356,8 +356,8 @@ const createSamplerSelect = <T extends string = string>(
               letter-spacing: 0.5px;
             `,
           },
-          config.label
-        )
+          config.label,
+        ),
       );
     }
 
@@ -370,9 +370,9 @@ const createSamplerSelect = <T extends string = string>(
         {
           style: `font-size: var(--ac-font-size-sm, 12px); color: var(--ac-color-text-primary);`,
         },
-        `${config.label}:`
+        `${config.label}:`,
       ),
-      SelectElement
+      SelectElement,
     );
   };
 };
@@ -383,28 +383,28 @@ export const KeymapSelect = createSamplerSelect(
   keymapSelectConfig,
   getSampler,
   van,
-  COMPONENT_STYLE
+  COMPONENT_STYLE,
 );
 
 export const WaveformSelect = createSamplerSelect(
   waveformSelectConfig,
   getSampler,
   van,
-  COMPONENT_STYLE
+  COMPONENT_STYLE,
 );
 
 export const InputSourceSelect = createSamplerSelect(
   inputSourceSelectConfig,
   getSampler,
   van,
-  COMPONENT_STYLE
+  COMPONENT_STYLE,
 );
 
 export const RootNoteSelect = createSamplerSelect(
   rootNoteSelectConfig,
   getSampler,
   van,
-  COMPONENT_STYLE
+  COMPONENT_STYLE,
 );
 
 // ===== SHARED SELECT STATE REGISTRY =====

--- a/packages/audio-components/src/elements/primitives/createSVGButton.ts
+++ b/packages/audio-components/src/elements/primitives/createSVGButton.ts
@@ -57,8 +57,7 @@ const icons = new Map<string, string>([
   [
     'record_recording',
     `<svg viewBox="0 0 24 24" fill="currentColor">
-      <circle cx="12" cy="12" r="10" />
-      <circle cx="12" cy="12" r="6" fill="white" />
+      <circle cx="12" cy="12" r="12" />
     </svg>`,
   ],
 
@@ -207,7 +206,7 @@ const applySizeStyles = (button: HTMLButtonElement, size: ButtonSize): void => {
 export function createSVGButton(
   title: string,
   states: string | string[],
-  options: ButtonOptions = {}
+  options: ButtonOptions = {},
 ): HTMLButtonElement {
   const stateArray = Array.isArray(states) ? states : [states];
   let currentStateIndex = 0;
@@ -254,7 +253,7 @@ export function createSVGButton(
       if (stateArray.length > 1) {
         button.setAttribute(
           'aria-pressed',
-          currentStateIndex !== 0 ? 'true' : 'false'
+          currentStateIndex !== 0 ? 'true' : 'false',
         );
       }
     }

--- a/packages/audiolib/src/context/globalAudioContext.ts
+++ b/packages/audiolib/src/context/globalAudioContext.ts
@@ -105,6 +105,12 @@ export async function getAudioOutputDevices(): Promise<MediaDeviceInfo[]> {
   return devices.filter((d) => d.kind === 'audiooutput');
 }
 
+/** Device labels are only populated once mic permission has been granted */
+export async function getAudioInputDevices(): Promise<MediaDeviceInfo[]> {
+  const devices = await navigator.mediaDevices.enumerateDevices();
+  return devices.filter((d) => d.kind === 'audioinput');
+}
+
 /** Routes the global AudioContext (all audiolib output) to the given output device.
  *  Pass '' or 'default' to restore the system default output. */
 export async function setAudioOutputDevice(deviceId: string): Promise<void> {

--- a/packages/audiolib/src/index.ts
+++ b/packages/audiolib/src/index.ts
@@ -20,6 +20,7 @@ export type {
 export { getAudioContext, ensureAudioCtx } from './context';
 export {
   canSetOutputDevice,
+  getAudioInputDevices,
   getAudioOutputDevices,
   setAudioOutputDevice,
   getCurrentOutputDeviceId,

--- a/packages/audiolib/src/io/devices/devices.test.ts
+++ b/packages/audiolib/src/io/devices/devices.test.ts
@@ -84,6 +84,39 @@ describe('Device Access Utils', () => {
       });
     });
 
+    it('falls back to default input when requested device is unavailable', async () => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const overconstrained = Object.assign(new Error('unavailable'), {
+        name: 'OverconstrainedError',
+      });
+      vi.mocked(navigator.mediaDevices.getUserMedia)
+        .mockRejectedValueOnce(overconstrained)
+        .mockResolvedValueOnce(mockStream);
+
+      const stream = await getMicrophone(undefined, 'gone-device');
+
+      expect(stream).toBe(mockStream);
+      expect(navigator.mediaDevices.getUserMedia).toHaveBeenLastCalledWith({
+        audio: {
+          echoCancellation: false,
+          noiseSuppression: true,
+          autoGainControl: true,
+        },
+      });
+      consoleSpy.mockRestore();
+    });
+
+    it('rethrows non-OverconstrainedError failures', async () => {
+      const denied = Object.assign(new Error('denied'), {
+        name: 'NotAllowedError',
+      });
+      vi.mocked(navigator.mediaDevices.getUserMedia).mockRejectedValue(denied);
+
+      await expect(getMicrophone(undefined, 'input-123')).rejects.toThrow(
+        'denied'
+      );
+    });
+
     it('gets camera access', async () => {
       const stream = await getCamera();
       expect(stream).toBe(mockStream);

--- a/packages/audiolib/src/io/devices/devices.test.ts
+++ b/packages/audiolib/src/io/devices/devices.test.ts
@@ -70,6 +70,20 @@ describe('Device Access Utils', () => {
       );
     });
 
+    it('requests a specific audio input device when provided', async () => {
+      const stream = await getMicrophone(undefined, 'input-123');
+
+      expect(stream).toBe(mockStream);
+      expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({
+        audio: {
+          echoCancellation: false,
+          noiseSuppression: true,
+          autoGainControl: true,
+          deviceId: { exact: 'input-123' },
+        },
+      });
+    });
+
     it('gets camera access', async () => {
       const stream = await getCamera();
       expect(stream).toBe(mockStream);

--- a/packages/audiolib/src/io/devices/devices.ts
+++ b/packages/audiolib/src/io/devices/devices.ts
@@ -35,10 +35,16 @@ export async function getMicrophone(
     echoCancellation: false,
     noiseSuppression: true, // ?
     autoGainControl: true, // ?
-  }
+  },
+  deviceId = ''
 ): Promise<MediaStream> {
   const stream = await navigator.mediaDevices.getUserMedia({
-    audio: constraints,
+    audio: deviceId
+      ? {
+          ...constraints,
+          deviceId: { exact: deviceId },
+        }
+      : constraints,
   });
   return stream;
 }

--- a/packages/audiolib/src/io/devices/devices.ts
+++ b/packages/audiolib/src/io/devices/devices.ts
@@ -38,15 +38,25 @@ export async function getMicrophone(
   },
   deviceId = ''
 ): Promise<MediaStream> {
-  const stream = await navigator.mediaDevices.getUserMedia({
-    audio: deviceId
-      ? {
-          ...constraints,
-          deviceId: { exact: deviceId },
-        }
-      : constraints,
-  });
-  return stream;
+  try {
+    return await navigator.mediaDevices.getUserMedia({
+      audio: deviceId
+        ? {
+            ...constraints,
+            deviceId: { exact: deviceId },
+          }
+        : constraints,
+    });
+  } catch (error) {
+    // Selected device unplugged/disabled -> fall back to default input
+    if (deviceId && (error as DOMException).name === 'OverconstrainedError') {
+      console.warn(
+        'Requested audio input device unavailable, falling back to default'
+      );
+      return navigator.mediaDevices.getUserMedia({ audio: constraints });
+    }
+    throw error;
+  }
 }
 
 // Video Input (Camera)

--- a/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
+++ b/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
@@ -103,7 +103,8 @@ export class SamplePlayer implements ILibInstrumentNode {
   voicePool!: SampleVoicePool; // todo: fix use of '!'
   outBus!: InstrumentBus; // todo: fix use of '!'
 
-  #recordInputSource: InputSource = 'microphone';
+  #recordInputSource: InputSource = 'audio-input';
+  #recordInputDeviceId = '';
 
   // ? move to input controller ?
   #sustainedNotes = new Set<MidiValue>();
@@ -191,6 +192,14 @@ export class SamplePlayer implements ILibInstrumentNode {
 
   getRecorderInputSource() {
     return this.#recordInputSource;
+  }
+
+  setRecorderInputDeviceId(deviceId: string) {
+    this.#recordInputDeviceId = deviceId === 'default' ? '' : deviceId;
+  }
+
+  getRecorderInputDeviceId() {
+    return this.#recordInputDeviceId;
   }
 
   // === MESSAGING ===

--- a/packages/audiolib/src/nodes/recorder/Recorder.ts
+++ b/packages/audiolib/src/nodes/recorder/Recorder.ts
@@ -45,7 +45,7 @@ export const DEFAULT_MEDIA_REC_OPTIONS: MediaRecorderOptions = {
   mimeType: 'audio/webm',
 };
 
-export type InputSource = 'microphone' | 'browser' | 'resample';
+export type InputSource = 'audio-input' | 'browser' | 'resample';
 
 export type RecorderOptions = {
   mediaRecorderOptions: MediaRecorderOptions;
@@ -86,7 +86,8 @@ export class Recorder implements LibNode {
   #animationFrame: number | null = null;
   #silenceStartTime: number | null = null;
   #config: RecorderOptions | null = null;
-  #inputSource: InputSource = 'microphone';
+  #inputSource: InputSource = 'audio-input';
+  #inputDeviceId = '';
 
   #audioDestination: MediaStreamAudioDestinationNode | null = null;
   #connectedSamplePlayer: SamplePlayer | null = null;
@@ -162,10 +163,12 @@ export class Recorder implements LibNode {
         streamResult
       );
     } else {
-      streamResult = await tryCatch(() => getMicrophone());
+      streamResult = await tryCatch(() =>
+        getMicrophone(undefined, this.#inputDeviceId)
+      );
       assert(
         !streamResult.error,
-        `Failed to get microphone: ${streamResult.error}`,
+        `Failed to get audio input: ${streamResult.error}`,
         streamResult
       );
     }
@@ -218,6 +221,10 @@ export class Recorder implements LibNode {
 
   setInputSource(source: InputSource) {
     this.#inputSource = source;
+  }
+
+  setInputDeviceId(deviceId: string) {
+    this.#inputDeviceId = deviceId === 'default' ? '' : deviceId;
   }
 
   #startArmedRecording(): void {


### PR DESCRIPTION
## Summary

Adds per-sampler audio input device selection for recording in the play app.

- Adds an `InputDeviceSelect` component mirroring the existing output-device selector pattern.
- Renames the recorder input source from `microphone` to the more accurate `audio-input`.
- Stores selected input device IDs per `SamplePlayer` and passes them through `Recorder` to `getUserMedia`.
- Exposes lightweight audio input enumeration from `audiolib`.
- Includes the current record icon adjustment from the tested worktree state.

## Validation

- Manually tested in `apps/play` by the user.
- `pnpm --filter @repo/audiolib exec vitest run src/io/devices/devices.test.ts`
- `pnpm build`

Note: `pnpm build` still emits the existing custom-select HTML warning for the input/output selector pattern, but completes successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an audio input device selector to the sampler UI, including “System Default Input”.
  * Device list refreshes on hardware changes and shows device labels after microphone permission is granted.
  * Recorder input now supports selecting a specific device (including system default) and preserves the choice when playback loads.
  * Updated input source naming to “Audio Input” terminology.
* **Bug Fixes**
  * Recording now correctly honors the selected audio input device, with safe fallback if a requested device isn’t available.
* **UI/Style**
  * Improved styling for the new selector and disabled states in the toolbar.
* **Tests**
  * Expanded coverage for device-selection and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->