### PR TITLE
Add keytrackLoopAmount: scale loop length by played note

### DIFF
--- a/apps/play/src/App.tsx
+++ b/apps/play/src/App.tsx
@@ -410,6 +410,7 @@ const App: Component = () => {
               <keytrack-loop-knob
                 target-node-id='test-sampler'
                 label='KeyTrack'
+                title='Only affects loops longer than audiorate'
               />
               <div class='flex-col'>
                 <loop-duration-drift-knob

--- a/apps/play/src/App.tsx
+++ b/apps/play/src/App.tsx
@@ -407,6 +407,10 @@ const App: Component = () => {
                 target-node-id='test-sampler'
                 label='Duration'
               />
+              <keytrack-loop-knob
+                target-node-id='test-sampler'
+                label='KeyTrack'
+              />
               <div class='flex-col'>
                 <loop-duration-drift-knob
                   target-node-id='test-sampler'

--- a/apps/play/src/types/global.d.ts
+++ b/apps/play/src/types/global.d.ts
@@ -45,6 +45,7 @@ declare module 'solid-js' {
       'loop-start-knob': any;
       'loop-duration-knob': any;
       'loop-duration-drift-knob': any;
+      'keytrack-loop-knob': any;
       'am-modulation': any;
       'trim-start-knob': any;
       'trim-end-knob': any;

--- a/packages/audio-components/src/elements/Sampler/Sampler.ts
+++ b/packages/audio-components/src/elements/Sampler/Sampler.ts
@@ -27,6 +27,7 @@ import {
   LoopStartKnob,
   LoopDurationKnob,
   LoopDurationDriftKnob,
+  KeytrackLoopKnob,
   AMModKnob,
   TrimStartKnob,
   TrimEndKnob,
@@ -366,6 +367,7 @@ export {
   LoopStartKnob,
   LoopDurationKnob,
   LoopDurationDriftKnob,
+  KeytrackLoopKnob,
   AMModKnob,
   TrimStartKnob,
   TrimEndKnob,
@@ -448,6 +450,7 @@ export const defineSampler = () => {
   defineIfNotExists('loop-start-knob', LoopStartKnob, false);
   defineIfNotExists('loop-duration-knob', LoopDurationKnob, false);
   defineIfNotExists('loop-duration-drift-knob', LoopDurationDriftKnob, false);
+  defineIfNotExists('keytrack-loop-knob', KeytrackLoopKnob, false);
   defineIfNotExists('trim-start-knob', TrimStartKnob, false);
   defineIfNotExists('trim-end-knob', TrimEndKnob, false);
   defineIfNotExists('distortion-knob', DistortionKnob, false);

--- a/packages/audio-components/src/elements/Sampler/components/SamplerKnobFactory.ts
+++ b/packages/audio-components/src/elements/Sampler/components/SamplerKnobFactory.ts
@@ -285,10 +285,25 @@ const keytrackLoopConfig: KnobConfig = {
   minValue: 0,
   maxValue: 1,
   curve: 1,
-  // '—' at 0 signals "no effect" (also inert below audio-rate loop lengths — see loop knob)
-  valueFormatter: (v: number) => (v === 0 ? '—' : `${(v * 100).toFixed(0)}%`),
-  onConnect: (sampler, state) => {
+  valueFormatter: (v: number) => `${(v * 100).toFixed(0)}%`,
+  onConnect: (sampler, state, knobElement) => {
     van.derive(() => sampler.setKeytrackLoopAmount(state.val));
+
+    // Dim when the loop is audio-rate (<= PITCH_PRESERVATION_THRESHOLD), where keytrack
+    // has no effect. loop-points:updated fires on every loop change, so this stays live.
+    // NOTE: the sampler.loopEnd/loopStart getters lag (macro ramps async); the message
+    // payload carries the authoritative target, so prefer it when present.
+    const AUDIO_RATE_SECONDS = 0.061;
+    const updateHint = (msg?: { loopStart: number; loopEnd: number }) => {
+      if (!knobElement) return;
+      const loopStart = msg ? msg.loopStart : sampler.loopStart;
+      const loopEnd = msg ? msg.loopEnd : sampler.loopEnd;
+      knobElement.style.opacity =
+        loopEnd - loopStart <= AUDIO_RATE_SECONDS ? '0.4' : '';
+    };
+    updateHint();
+    sampler.onMessage('loop-points:updated', (msg: any) => updateHint(msg));
+    sampler.onMessage('sample:loaded', () => updateHint());
   },
 };
 
@@ -426,9 +441,9 @@ const loopDurationConfig: KnobConfig = {
   curve: 4,
   snapIncrement: 0,
   // Below ~61ms the loop is audio-rate (PITCH_PRESERVATION_THRESHOLD in the processor):
-  // its retrigger rate becomes the pitch, and keytrack has no effect here.
+  // switch to a compact ms readout as a subtle cue (keytrack has no effect here).
   valueFormatter: (v: number) =>
-    v <= 0.061 ? `${(v * 1000).toFixed(0)} ms · audio-rate` : `${v.toFixed(2)} s`,
+    v <= 0.061 ? `${(v * 1000).toFixed(0)}ms` : `${v.toFixed(2)} s`,
   onConnect: (sampler, state, knobElement) => {
     if (knobElement) {
       const currentDuration = sampler.sampleDuration;

--- a/packages/audio-components/src/elements/Sampler/components/SamplerKnobFactory.ts
+++ b/packages/audio-components/src/elements/Sampler/components/SamplerKnobFactory.ts
@@ -276,6 +276,21 @@ const loopDurationDriftConfig: KnobConfig = {
   },
 };
 
+const keytrackLoopConfig: KnobConfig = {
+  label: 'KeyTrack',
+  // NOTE: double-persists — this knob's useLocalStorage AND SamplePlayer.storeParamValue
+  // both save it (knob store wins on reload). Matches loopDurationDrift; dedupe deferred.
+  useLocalStorage: true,
+  defaultValue: 0,
+  minValue: 0,
+  maxValue: 1,
+  curve: 1,
+  valueFormatter: (v: number) => `${(v * 100).toFixed(0)}%`,
+  onConnect: (sampler, state) => {
+    van.derive(() => sampler.setKeytrackLoopAmount(state.val));
+  },
+};
+
 const lowpassFilterConfig: KnobConfig = {
   label: 'LPF',
   useLocalStorage: true,
@@ -526,6 +541,11 @@ export const DelayFeedbackKnob = createKnobForTarget(delayFBConfig, getSampler);
 
 export const LoopDurationDriftKnob = createKnobForTarget(
   loopDurationDriftConfig,
+  getSampler
+);
+
+export const KeytrackLoopKnob = createKnobForTarget(
+  keytrackLoopConfig,
   getSampler
 );
 

--- a/packages/audio-components/src/elements/Sampler/components/SamplerKnobFactory.ts
+++ b/packages/audio-components/src/elements/Sampler/components/SamplerKnobFactory.ts
@@ -285,7 +285,8 @@ const keytrackLoopConfig: KnobConfig = {
   minValue: 0,
   maxValue: 1,
   curve: 1,
-  valueFormatter: (v: number) => `${(v * 100).toFixed(0)}%`,
+  // '—' at 0 signals "no effect" (also inert below audio-rate loop lengths — see loop knob)
+  valueFormatter: (v: number) => (v === 0 ? '—' : `${(v * 100).toFixed(0)}%`),
   onConnect: (sampler, state) => {
     van.derive(() => sampler.setKeytrackLoopAmount(state.val));
   },
@@ -424,6 +425,10 @@ const loopDurationConfig: KnobConfig = {
   maxValue: 1,
   curve: 4,
   snapIncrement: 0,
+  // Below ~61ms the loop is audio-rate (PITCH_PRESERVATION_THRESHOLD in the processor):
+  // its retrigger rate becomes the pitch, and keytrack has no effect here.
+  valueFormatter: (v: number) =>
+    v <= 0.061 ? `${(v * 1000).toFixed(0)} ms · audio-rate` : `${v.toFixed(2)} s`,
   onConnect: (sampler, state, knobElement) => {
     if (knobElement) {
       const currentDuration = sampler.sampleDuration;

--- a/packages/audio-components/src/elements/Sampler/components/SamplerKnobFactory.ts
+++ b/packages/audio-components/src/elements/Sampler/components/SamplerKnobFactory.ts
@@ -289,20 +289,23 @@ const keytrackLoopConfig: KnobConfig = {
   onConnect: (sampler, state, knobElement) => {
     van.derive(() => sampler.setKeytrackLoopAmount(state.val));
 
-    // Dim when the loop is audio-rate (<= PITCH_PRESERVATION_THRESHOLD), where keytrack
-    // has no effect. loop-points:updated fires on every loop change, so this stays live.
+    // Dim when keytrack has no effect: loop off, or loop audio-rate
+    // (<= PITCH_PRESERVATION_THRESHOLD). Stays live via loop:enabled / loop-points:updated.
     // NOTE: the sampler.loopEnd/loopStart getters lag (macro ramps async); the message
-    // payload carries the authoritative target, so prefer it when present.
+    // payload carries the authoritative target, so prefer it when present. loopEnabled
+    // getter is synchronous, so it's read directly.
     const AUDIO_RATE_SECONDS = 0.061;
     const updateHint = (msg?: { loopStart: number; loopEnd: number }) => {
       if (!knobElement) return;
       const loopStart = msg ? msg.loopStart : sampler.loopStart;
       const loopEnd = msg ? msg.loopEnd : sampler.loopEnd;
-      knobElement.style.opacity =
-        loopEnd - loopStart <= AUDIO_RATE_SECONDS ? '0.4' : '';
+      const inactive =
+        !sampler.loopEnabled || loopEnd - loopStart <= AUDIO_RATE_SECONDS;
+      knobElement.style.opacity = inactive ? '0.4' : '';
     };
     updateHint();
     sampler.onMessage('loop-points:updated', (msg: any) => updateHint(msg));
+    sampler.onMessage('loop:enabled', () => updateHint());
     sampler.onMessage('sample:loaded', () => updateHint());
   },
 };

--- a/packages/audio-components/src/index.ts
+++ b/packages/audio-components/src/index.ts
@@ -55,6 +55,7 @@ export {
   LoopStartKnob,
   LoopDurationKnob,
   LoopDurationDriftKnob,
+  KeytrackLoopKnob,
   AMModKnob,
   TrimStartKnob,
   TrimEndKnob,

--- a/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
+++ b/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
@@ -112,7 +112,7 @@ export class SamplePlayer implements ILibInstrumentNode {
   constructor(
     context: AudioContext,
     polyphony: number = 16,
-    audioBuffer?: AudioBuffer
+    audioBuffer?: AudioBuffer,
   ) {
     this.nodeId = registerNode('sample-player', this);
     this.context = context;
@@ -124,12 +124,12 @@ export class SamplePlayer implements ILibInstrumentNode {
 
     this.#macroLoopStart = new MacroParam(
       this.context,
-      DEFAULT_PARAM_DESCRIPTORS.LOOP_START
+      DEFAULT_PARAM_DESCRIPTORS.LOOP_START,
     );
 
     this.#macroLoopEnd = new MacroParam(
       this.context,
-      DEFAULT_PARAM_DESCRIPTORS.LOOP_END
+      DEFAULT_PARAM_DESCRIPTORS.LOOP_END,
     );
 
     // Store configuration for async init
@@ -147,7 +147,7 @@ export class SamplePlayer implements ILibInstrumentNode {
         this.outBus = await createInstrumentBus(this.context); // WIP
         this.voicePool = await createSampleVoicePool(
           this.context,
-          this.#polyphony
+          this.#polyphony,
         );
 
         this.#resetMacros();
@@ -307,12 +307,12 @@ export class SamplePlayer implements ILibInstrumentNode {
   protected storeParamValue(
     paramId: string,
     value: any,
-    delay = this.#debounceMs
+    delay = this.#debounceMs,
   ): void {
     this.#debouncer.debounce(
       () => localStore.saveValue(this.getLocalStorageKey(paramId), value),
       delay,
-      paramId
+      paramId,
     )();
   }
 
@@ -321,7 +321,7 @@ export class SamplePlayer implements ILibInstrumentNode {
    */
   getStoredParamValue<T extends number | string>(
     paramId: string,
-    defaultValue: T
+    defaultValue: T,
   ): T {
     const key = this.getLocalStorageKey(paramId);
     return localStore.getValue(key, defaultValue);
@@ -434,16 +434,16 @@ export class SamplePlayer implements ILibInstrumentNode {
 
   setModulationAmount = (modType: 'AM' | 'FM', amount: number) =>
     this.voicePool.applyToAllVoices((v) =>
-      v.setModulationAmount(modType, amount)
+      v.setModulationAmount(modType, amount),
     );
 
   setModulationWaveform(
     modType: 'AM' | 'FM' = 'AM',
     waveform: CustomLibWaveform | OscillatorType | PeriodicWave = 'triangle',
-    customWaveOptions: WaveformOptions = {}
+    customWaveOptions: WaveformOptions = {},
   ) {
     this.voicePool.applyToAllVoices((v) =>
-      v.setModulationWaveform(modType, waveform, customWaveOptions)
+      v.setModulationWaveform(modType, waveform, customWaveOptions),
     );
   }
 
@@ -493,7 +493,7 @@ export class SamplePlayer implements ILibInstrumentNode {
 
   freezeActiveVoices(freeze: boolean): this {
     console.info(
-      `SamplePlayer: freezeActiveVoices(${freeze}). Spectral freeze not implemented yet`
+      `SamplePlayer: freezeActiveVoices(${freeze}). Spectral freeze not implemented yet`,
     );
     // this.voicePool.applyToActiveVoices((voice) => voice.freeze(freeze));
     return this;
@@ -504,7 +504,7 @@ export class SamplePlayer implements ILibInstrumentNode {
   async loadSample(
     buffer: AudioBuffer | ArrayBuffer,
     modSampleRate?: number,
-    preprocessOptions?: Partial<PreProcessOptions>
+    preprocessOptions?: Partial<PreProcessOptions>,
   ): Promise<AudioBuffer | null> {
     if (buffer instanceof ArrayBuffer) {
       const ctx = getAudioContext();
@@ -524,7 +524,7 @@ export class SamplePlayer implements ILibInstrumentNode {
         `sample rate mismatch, 
         buffer rate: ${buffer.sampleRate}, 
         context rate: ${this.context.sampleRate}
-        requested rate: ${modSampleRate}`
+        requested rate: ${modSampleRate}`,
       );
     }
 
@@ -539,7 +539,7 @@ export class SamplePlayer implements ILibInstrumentNode {
       processed = await preProcessAudioBuffer(
         this.context,
         buffer,
-        preprocessOptions
+        preprocessOptions,
       );
       buffer = processed.audiobuffer;
 
@@ -597,7 +597,7 @@ export class SamplePlayer implements ILibInstrumentNode {
 
   detectedPitchToTransposition(
     detectedMidiFloat: number,
-    targetMidiNote: number
+    targetMidiNote: number,
   ) {
     let transposeSemitones = targetMidiNote - detectedMidiFloat;
     // Wrap to nearest octave (-6 to +6 semitones)
@@ -611,7 +611,7 @@ export class SamplePlayer implements ILibInstrumentNode {
   play(
     midiNote: MidiValue,
     velocity: MidiValue = 100,
-    glideTime = this.getGlideTime()
+    glideTime = this.getGlideTime(),
   ): MidiValue | null {
     const safeVelocity = isMidiValue(velocity) ? velocity : 100;
     const transposedMidiNote = midiNote + this.#transposedBySemitones;
@@ -631,7 +631,7 @@ export class SamplePlayer implements ILibInstrumentNode {
       transposedMidiNote,
       safeVelocity,
       0,
-      glideTime
+      glideTime,
     );
   }
 
@@ -832,7 +832,7 @@ export class SamplePlayer implements ILibInstrumentNode {
 
   setPlaybackDirection(direction: 'forward' | 'reverse'): this {
     this.voicePool.applyToAllVoices((voice) =>
-      voice.setPlaybackDirection(direction)
+      voice.setPlaybackDirection(direction),
     );
 
     this.storeParamValue('playbackDirection', direction);
@@ -841,7 +841,7 @@ export class SamplePlayer implements ILibInstrumentNode {
 
   setLoopDurationDriftAmount(amount: number): this {
     this.voicePool.applyToAllVoices((voice) =>
-      voice.setLoopDurationDriftAmount(amount)
+      voice.setLoopDurationDriftAmount(amount),
     );
 
     this.storeParamValue('loopDurationDrift', amount);
@@ -850,7 +850,7 @@ export class SamplePlayer implements ILibInstrumentNode {
 
   setPanDriftEnabled = (enabled: boolean) => {
     this.voicePool.applyToAllVoices((voice) =>
-      voice.setPanDriftEnabled(enabled)
+      voice.setPanDriftEnabled(enabled),
     );
 
     this.storeParamValue('panDriftEnabled', enabled);
@@ -864,27 +864,27 @@ export class SamplePlayer implements ILibInstrumentNode {
 
   setLoopStart = (
     seconds: number,
-    rampTime: number = this.getLoopRampDuration()
+    rampTime: number = this.getLoopRampDuration(),
   ) => {
     return this.setLoopPoint('start', seconds, this.loopEnd, rampTime);
   };
 
   setLoopEnd = (
     seconds: number,
-    rampTime: number = this.getLoopRampDuration()
+    rampTime: number = this.getLoopRampDuration(),
   ) => {
     return this.setLoopPoint('end', this.loopStart, seconds, rampTime);
   };
 
   setLoopDuration = (
     seconds: number,
-    rampTime: number = this.getLoopRampDuration()
+    rampTime: number = this.getLoopRampDuration(),
   ) =>
     this.setLoopPoint(
       'end',
       this.loopStart,
       this.loopStart + seconds,
-      rampTime
+      rampTime,
     );
 
   debugcounter = 0;
@@ -901,15 +901,20 @@ export class SamplePlayer implements ILibInstrumentNode {
 
   syncLoopToTempo(enabled: boolean) {
     this.voicePool.applyToAllVoices((voice) => voice.syncLoopToTempo(enabled));
-  }
-
-  // PoC: keytrack loop length to the played note (0 = fixed samples, 1 = constant loop time)
-  setKeytrackLoopAmount(amount: number) {
-    this.voicePool.applyToAllVoices((voice) =>
-      voice.sendToProcessor({ type: 'setKeytrackLoopAmount', value: amount })
-    );
     return this;
   }
+
+  // Keytrack loop length to the played note (0 = fixed samples, 1 = constant loop time)
+  setKeytrackLoopAmount(amount: number) {
+    this.voicePool.applyToAllVoices((voice) =>
+      voice.setKeytrackLoopAmount(amount)
+    );
+    this.storeParamValue('keytrackLoopAmount', amount);
+    return this;
+  }
+
+  getKeytrackLoopAmount = () =>
+    this.getStoredParamValue('keytrackLoopAmount', 0);
 
   get tempo() {
     return this.#tempo;
@@ -919,12 +924,12 @@ export class SamplePlayer implements ILibInstrumentNode {
     loopPoint: 'start' | 'end',
     loopStartSeconds: number,
     loopEndSeconds: number,
-    rampDuration: number = this.getLoopRampDuration()
+    rampDuration: number = this.getLoopRampDuration(),
   ) {
     let loopStart = clamp(
       loopStartSeconds,
       0 + this.MIN_LOOP_DURATION_SECONDS / 2,
-      loopEndSeconds
+      loopEndSeconds,
     );
 
     if (loopPoint === 'start' && loopStart === this.loopStart) return this;
@@ -932,7 +937,7 @@ export class SamplePlayer implements ILibInstrumentNode {
     let loopEnd = clamp(
       loopEndSeconds,
       loopStart,
-      this.#bufferDuration - this.MIN_LOOP_DURATION_SECONDS / 2
+      this.#bufferDuration - this.MIN_LOOP_DURATION_SECONDS / 2,
     );
 
     if (loopPoint === 'end' && loopEnd === this.loopEnd) return this;
@@ -1028,21 +1033,21 @@ export class SamplePlayer implements ILibInstrumentNode {
   getStartPoint(): number {
     return this.getStoredParamValue(
       'startPoint',
-      DEFAULT_PARAM_DESCRIPTORS.START_POINT.defaultValue
+      DEFAULT_PARAM_DESCRIPTORS.START_POINT.defaultValue,
     );
   }
 
   getEndPoint(): number {
     return this.getStoredParamValue(
       'endPoint',
-      DEFAULT_PARAM_DESCRIPTORS.END_POINT.defaultValue
+      DEFAULT_PARAM_DESCRIPTORS.END_POINT.defaultValue,
     );
   }
 
   getLoopRampDuration(): number {
     return this.getStoredParamValue(
       'loopRampDuration',
-      DEFAULT_PARAM_DESCRIPTORS.LOOP_RAMP_DURATION.defaultValue
+      DEFAULT_PARAM_DESCRIPTORS.LOOP_RAMP_DURATION.defaultValue,
     );
   }
 
@@ -1119,34 +1124,34 @@ export class SamplePlayer implements ILibInstrumentNode {
   setEnvelopeLoop = (
     envType: EnvelopeType,
     loop: boolean,
-    mode: 'normal' | 'ping-pong' | 'reverse' = 'normal'
+    mode: 'normal' | 'ping-pong' | 'reverse' = 'normal',
   ) => {
     this.voicePool.applyToAllVoices((v) =>
-      v.setEnvelopeLoop(envType, loop, mode)
+      v.setEnvelopeLoop(envType, loop, mode),
     );
   };
 
   setEnvelopeSync = (envType: EnvelopeType, sync: boolean) => {
     this.voicePool.applyToAllVoices((v) =>
-      v.syncEnvelopeToPlaybackRate(envType, sync)
+      v.syncEnvelopeToPlaybackRate(envType, sync),
     );
   };
 
   setEnvelopeTimeScale = (envType: EnvelopeType, timeScale: number) => {
     this.voicePool.applyToAllVoices((v) =>
-      v.setEnvelopeTimeScale(envType, timeScale)
+      v.setEnvelopeTimeScale(envType, timeScale),
     );
   };
 
   setEnvelopeSustainPoint(envType: EnvelopeType, index: number | null) {
     this.voicePool.applyToAllVoices((v) =>
-      v.setEnvelopeSustainPoint(envType, index)
+      v.setEnvelopeSustainPoint(envType, index),
     );
   }
 
   setEnvelopeReleasePoint(envType: EnvelopeType, index: number) {
     this.voicePool.applyToAllVoices((v) =>
-      v.setEnvelopeReleasePoint(envType, index)
+      v.setEnvelopeReleasePoint(envType, index),
     );
   }
 
@@ -1154,22 +1159,22 @@ export class SamplePlayer implements ILibInstrumentNode {
     envType: EnvelopeType,
     index: number,
     time: number,
-    value: number
+    value: number,
   ): void {
     this.voicePool.applyToAllVoices((v) =>
-      v.updateEnvelopePoint(envType, index, time, value)
+      v.updateEnvelopePoint(envType, index, time, value),
     );
   }
 
   addEnvelopePoint(envType: EnvelopeType, time: number, value: number): void {
     this.voicePool.applyToAllVoices((v) =>
-      v.addEnvelopePoint(envType, time, value)
+      v.addEnvelopePoint(envType, time, value),
     );
   }
 
   deleteEnvelopePoint(envType: EnvelopeType, index: number): void {
     this.voicePool.applyToAllVoices((v) =>
-      v.deleteEnvelopePoint(envType, index)
+      v.deleteEnvelopePoint(envType, index),
     );
   }
 

--- a/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
+++ b/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
@@ -906,15 +906,25 @@ export class SamplePlayer implements ILibInstrumentNode {
 
   // Keytrack loop length to the played note (0 = fixed samples, 1 = constant loop time)
   setKeytrackLoopAmount(amount: number) {
+    const clamped = Math.max(0, Math.min(1, amount));
+    this.#keytrackLoopAmount = clamped;
     this.voicePool.applyToAllVoices((voice) =>
-      voice.setKeytrackLoopAmount(amount)
+      voice.setKeytrackLoopAmount(clamped)
     );
-    this.storeParamValue('keytrackLoopAmount', amount);
+    this.storeParamValue('keytrackLoopAmount', clamped);
     return this;
   }
 
-  getKeytrackLoopAmount = () =>
-    this.getStoredParamValue('keytrackLoopAmount', 0);
+  // storeParamValue is debounced, so keep the live value in memory for the getter
+  #keytrackLoopAmount: number | null = null;
+
+  getKeytrackLoopAmount = () => {
+    this.#keytrackLoopAmount ??= this.getStoredParamValue(
+      'keytrackLoopAmount',
+      0
+    );
+    return this.#keytrackLoopAmount;
+  };
 
   get tempo() {
     return this.#tempo;

--- a/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
+++ b/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
@@ -903,6 +903,14 @@ export class SamplePlayer implements ILibInstrumentNode {
     this.voicePool.applyToAllVoices((voice) => voice.syncLoopToTempo(enabled));
   }
 
+  // PoC: keytrack loop length to the played note (0 = fixed samples, 1 = constant loop time)
+  setKeytrackLoopAmount(amount: number) {
+    this.voicePool.applyToAllVoices((voice) =>
+      voice.sendToProcessor({ type: 'setKeytrackLoopAmount', value: amount })
+    );
+    return this;
+  }
+
   get tempo() {
     return this.#tempo;
   }

--- a/packages/audiolib/src/nodes/instruments/Sample/SampleVoice.ts
+++ b/packages/audiolib/src/nodes/instruments/Sample/SampleVoice.ts
@@ -791,6 +791,14 @@ export class SampleVoice {
     return this;
   }
 
+  setKeytrackLoopAmount(amount: number) {
+    this.sendToProcessor({
+      type: 'setKeytrackLoopAmount',
+      value: amount,
+    });
+    return this;
+  }
+
   setTempo(bpm: number) {
     this.setParam('tempo', bpm, this.now);
     return this;

--- a/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
+++ b/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
@@ -117,7 +117,7 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
     // Keytrack loop: 0 = loop length fixed in samples (loop time shortens as you play higher).
     // 1 = loop length scales with playbackRate so real-time loop period stays constant across notes.
     // NOTE: Using keytrackLoopAmount > 0 means that audio-rate loop lengths no longer quantize to midinote
-    this.keytrackLoopAmount = 0;
+    this.keytrackLoopAmount = 1;
 
     // C0 (lowest piano note) = ~16.35 Hz
     // Period = 1/16.35 ≈ 0.061 seconds
@@ -493,17 +493,7 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
         : playbackRange.endSamples;
 
     let baseDuration = calcLoopEnd - calcLoopStart;
-
-    // Keytrack loop: scale sample-domain loop length by playbackRate so the real-time
-    // loop period stays constant across notes (amount=1); amount=0 leaves it fixed.
-    if (this.keytrackLoopAmount > 0) {
-      const scale = 1 + this.keytrackLoopAmount * (Math.abs(playbackRate) - 1);
-      baseDuration = Math.max(1, Math.floor(baseDuration * scale));
-      calcLoopEnd = Math.min(
-        playbackRange.endSamples,
-        calcLoopStart + baseDuration,
-      );
-    }
+    let isTempoSynced = false;
 
     // Apply tempo quantization if enabled
     if (this.syncLoopToTempo) {
@@ -512,10 +502,26 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
         tempo,
         playbackRate,
       );
-      calcLoopEnd = calcLoopStart + quantizedDuration;
+      isTempoSynced = quantizedDuration === baseDuration;
 
+      calcLoopEnd = calcLoopStart + quantizedDuration;
       // Ensure we don't exceed playback range
       calcLoopEnd = Math.min(calcLoopEnd, playbackRange.endSamples);
+    }
+
+    // Keytrack loop: scale sample-domain loop length by playbackRate so the real-time
+    // loop period stays constant across notes (amount=1); amount=0 leaves it fixed.
+    if (
+      baseDuration > this.PITCH_PRESERVATION_THRESHOLD &&
+      this.keytrackLoopAmount > 0 &&
+      !isTempoSynced
+    ) {
+      const scale = 1 + this.keytrackLoopAmount * (Math.abs(playbackRate) - 1);
+      baseDuration = Math.max(1, Math.floor(baseDuration * scale));
+      calcLoopEnd = Math.min(
+        playbackRange.endSamples,
+        calcLoopStart + baseDuration,
+      );
     }
 
     // Only snap to zero crossing if it doesnt affect pitch (audio-rate loop duration)

--- a/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
+++ b/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
@@ -511,6 +511,9 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
 
     // Keytrack loop: scale sample-domain loop length by playbackRate so the real-time
     // loop period stays constant across notes (amount=1); amount=0 leaves it fixed.
+    // Keytrack and tempo-sync both remap loop length as a function of playbackRate, in
+    // opposite directions (real-time vs. musical length). They are mutually exclusive:
+    // tempo-sync wins when it is active, so keytrack is skipped via !isTempoSynced.
     if (
       baseDuration > this.PITCH_PRESERVATION_THRESHOLD &&
       this.keytrackLoopAmount > 0 &&

--- a/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
+++ b/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
@@ -493,7 +493,6 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
         : playbackRange.endSamples;
 
     let baseDuration = calcLoopEnd - calcLoopStart;
-    let isTempoSynced = false;
 
     // Apply tempo quantization if enabled
     if (this.syncLoopToTempo) {
@@ -502,7 +501,6 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
         tempo,
         playbackRate,
       );
-      isTempoSynced = quantizedDuration !== baseDuration;
 
       calcLoopEnd = calcLoopStart + quantizedDuration;
       // Ensure we don't exceed playback range
@@ -513,11 +511,12 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
     // loop period stays constant across notes (amount=1); amount=0 leaves it fixed.
     // Keytrack and tempo-sync both remap loop length as a function of playbackRate, in
     // opposite directions (real-time vs. musical length). They are mutually exclusive:
-    // tempo-sync wins when it is active, so keytrack is skipped via !isTempoSynced.
+    // tempo-sync wins whenever it is enabled, even when quantization left the
+    // duration unchanged (already on-grid, or too short to quantize).
     if (
       baseDuration > this.PITCH_PRESERVATION_THRESHOLD &&
       this.keytrackLoopAmount > 0 &&
-      !isTempoSynced
+      !this.syncLoopToTempo
     ) {
       const scale = 1 + this.keytrackLoopAmount * (Math.abs(playbackRate) - 1);
       baseDuration = Math.max(1, Math.floor(baseDuration * scale));

--- a/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
+++ b/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
@@ -534,7 +534,6 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
     // Only snap to zero crossing if it doesnt affect pitch (audio-rate loop duration)
     if (baseDuration > this.PITCH_PRESERVATION_THRESHOLD) {
       calcLoopStart = this.#findNearestZeroCrossing(calcLoopStart, 'right');
-      calcLoopEnd = this.#findNearestZeroCrossing(calcLoopEnd, 'left');
     }
 
     // Apply drift to loop end position
@@ -583,6 +582,15 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
     } else {
       // Ensure pan drift is set to zero if no loopDrift applied
       this.currentPanDrift = 0;
+    }
+
+    // Snap the end last: drift moves the wrap point, so snapping before drift
+    // leaves the actual loop end off a zero crossing -> discontinuity click.
+    if (baseDuration > this.PITCH_PRESERVATION_THRESHOLD) {
+      calcLoopEnd = Math.max(
+        calcLoopStart + 1,
+        this.#findNearestZeroCrossing(calcLoopEnd, 'left'),
+      );
     }
 
     const loopDuration = calcLoopEnd - calcLoopStart;

--- a/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
+++ b/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
@@ -502,7 +502,7 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
         tempo,
         playbackRate,
       );
-      isTempoSynced = quantizedDuration === baseDuration;
+      isTempoSynced = quantizedDuration !== baseDuration;
 
       calcLoopEnd = calcLoopStart + quantizedDuration;
       // Ensure we don't exceed playback range

--- a/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
+++ b/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
@@ -114,6 +114,10 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
     this.enableAdaptiveDrift = true; // Adaptive drift scaling based on loop duration
     this.enableAmplitudeCompensation = true; // Automatic makeup gain for short loops
     this.syncLoopToTempo = false; // Todo: add controls for interactive testing
+    // Keytrack loop: 0 = loop length fixed in samples (loop time shortens as you play higher).
+    // 1 = loop length scales with playbackRate so real-time loop period stays constant across notes.
+    // NOTE: Using keytrackLoopAmount > 0 means that audio-rate loop lengths no longer quantize to midinote
+    this.keytrackLoopAmount = 0;
 
     // C0 (lowest piano note) = ~16.35 Hz
     // Period = 1/16.35 ≈ 0.061 seconds
@@ -246,6 +250,10 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
           type: 'loop:syncToTempo',
           enabled: value,
         });
+        break;
+
+      case 'setKeytrackLoopAmount':
+        this.keytrackLoopAmount = Math.max(0, Math.min(1, value));
         break;
     }
   }
@@ -484,7 +492,18 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
         ? lpEnd
         : playbackRange.endSamples;
 
-    const baseDuration = calcLoopEnd - calcLoopStart;
+    let baseDuration = calcLoopEnd - calcLoopStart;
+
+    // Keytrack loop: scale sample-domain loop length by playbackRate so the real-time
+    // loop period stays constant across notes (amount=1); amount=0 leaves it fixed.
+    if (this.keytrackLoopAmount > 0) {
+      const scale = 1 + this.keytrackLoopAmount * (Math.abs(playbackRate) - 1);
+      baseDuration = Math.max(1, Math.floor(baseDuration * scale));
+      calcLoopEnd = Math.min(
+        playbackRange.endSamples,
+        calcLoopStart + baseDuration,
+      );
+    }
 
     // Apply tempo quantization if enabled
     if (this.syncLoopToTempo) {

--- a/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
+++ b/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
@@ -117,7 +117,7 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
     // Keytrack loop: 0 = loop length fixed in samples (loop time shortens as you play higher).
     // 1 = loop length scales with playbackRate so real-time loop period stays constant across notes.
     // NOTE: Using keytrackLoopAmount > 0 means that audio-rate loop lengths no longer quantize to midinote
-    this.keytrackLoopAmount = 1;
+    this.keytrackLoopAmount = 0;
 
     // C0 (lowest piano note) = ~16.35 Hz
     // Period = 1/16.35 ≈ 0.061 seconds

--- a/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
+++ b/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
@@ -527,6 +527,10 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
       );
     }
 
+    // Both branches above clamp calcLoopEnd, so re-derive the actual duration
+    // before drift uses it to size its minimum loop length.
+    baseDuration = calcLoopEnd - calcLoopStart;
+
     // Only snap to zero crossing if it doesnt affect pitch (audio-rate loop duration)
     if (baseDuration > this.PITCH_PRESERVATION_THRESHOLD) {
       calcLoopStart = this.#findNearestZeroCrossing(calcLoopStart, 'right');
@@ -735,7 +739,9 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
 
     const playbackRange = this.#calculatePlaybackRange(positionParams);
 
-    const basePlaybackRate = parameters.playbackRate[0];
+    // Playback advances at rate * transposition, so loop-length math must use both
+    const effectivePlaybackRate =
+      parameters.playbackRate[0] * this.transpositionPlaybackrate;
 
     const tempo = parameters.tempo[0];
 
@@ -744,7 +750,7 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
       playbackRange,
       parameters.loopDurationDriftAmount[0],
       tempo,
-      basePlaybackRate,
+      effectivePlaybackRate,
     );
 
     // Calculate amplitude compensation for short loops


### PR DESCRIPTION
## What
Per-voice `keytrackLoopAmount`: loop length follows the played note.

- `0` = loop length fixed in samples (current behavior)
- `1` = loop length scales with pitch so real-time loop period stays ~constant across notes
- in between = blend
- formula (`#calculateLoopRange`): `baseDuration *= 1 + amount * (|playbackRate| - 1)`, `playbackRate` comes from the note → per-voice automatically

## Plumbing
- `sample-player-processor.js`: `keytrackLoopAmount` state + `setKeytrackLoopAmount` message, applied in `#calculateLoopRange`
- `SampleVoice.setKeytrackLoopAmount` → posts message
- `SamplePlayer.setKeytrackLoopAmount` → all voices + `storeParamValue`; `getKeytrackLoopAmount` getter
- `<keytrack-loop-knob>` self-wiring element (mirrors `loop-duration-drift-knob`), in play app Loop group, labeled **KeyTrack**

## Only applies above PITCH_PRESERVATION_THRESHOLD (~61ms)
- below it the loop is an oscillator: retrigger rate = pitch (`pitch = sampleRate * playbackRate / loopDurationSamples`)
- scaling length by `playbackRate` there cancels the note → every note same pitch. So keytrack is gated to non-oscillator loops only.

## Keytrack vs tempo-sync = mutually exclusive
- both remap loop length as a function of `playbackRate`, opposite directions (real-time length vs musical length)
- priority: **tempo-sync wins, keytrack skipped** (`!isTempoSynced`)
- inactive today: `syncLoopToTempo` hardcoded `false`, no UI

## UX: inactive-state signalling
- **KeyTrack knob dims** (opacity 0.4) when it has no effect: loop off, or loop <= audio-rate. Live via `loop:enabled` + `loop-points:updated` messages.
- **Loop Length knob** shows compact `<n>ms` readout below the threshold (subtle audio-rate cue, useful regardless of keytrack).
- KeyTrack hover tooltip: 'Only affects loops longer than audiorate'.
- gotcha: `sampler.loopEnd/loopStart` getters lag (macro ramps async) — the dim reads the `loop-points:updated` payload instead. `loopEnabled` getter is synchronous.

## Bugfix: clicks when loop drift > 0

Pre-existing bug found while testing drift alongside keytrack, fixed here since keytrack shares `#calculateLoopRange`.

`calcLoopEnd` was snapped to a zero crossing, and *then* drift was added to it. So the value that snapping produced was never the value the loop actually wrapped on — the real wrap point sat on an arbitrary sample, making each loop restart a waveform discontinuity. Audible as tiny clicks at every drift > 0.

Fix: move the end snap to after the drift block. The start snap stays before it — `baseDuration` (which scales drift magnitude and `updateInterval`) and the `calcLoopStart + minLoopDuration` clamp both require a final start, and snapping the start later could push it past the drifted end.

Known residual: the end snap moves left, so it can shave the loop slightly under `minLoopDuration` — bounded by one zero-crossing interval, guarded positive by `calcLoopStart + 1`. Not chasing it unless it shows up at extreme drift on very short loops. Also unaddressed: material with sparse or no zero crossings (DC offset, dense noise) has nothing to snap to and would need a seam crossfade.

## Status
PoC, evaluated in the play app and working. Caveats below are pre-real-integration.

## Caveats before real integration
- **gate mismatch (revisit w/ tempo-sync):** keytrack gate tests `baseDuration` (raw samples); quantize tests `baseDuration / |playbackRate|` (rate-adjusted). High notes → a loop can pass one gate not the other → boundary handoff not clean. Thresholds also near-coincide by accident (32nd @120bpm ≈ 62.5ms ≈ threshold) and quantize floor moves with tempo.
- **audio-rate constant duplicated:** `0.061` is hardcoded in the processor (`PITCH_PRESERVATION_THRESHOLD`) and again in the UI (dim + duration hint). Export one shared constant from audiolib if this graduates.
- **double localStorage:** knob `useLocalStorage` + lib `storeParamValue` both persist it (knob wins on reload). Matches drift knob; dedupe deferred.
- **short sample + high note:** scaled loop end clamps to playback-range end → effect silently caps, no smarter fallback.
- **loop drift:** `loopDurationDriftAmount` + `minLoopDuration` floor use post-keytrack `baseDuration` → drift magnitude varies with note. (Clicking fixed, see below; magnitude-vs-note still untested.)
- **amplitude comp:** short-loop makeup gain keys off final loop length → per-note gain may shift. Untested.
- **glide:** sweeps `playbackRate` continuously → loop length moves mid-note. Untested. (reverse ok, uses `|playbackRate|`.)
- **formula unconfirmed:** linear `1 + amount*(rate-1)`, guessed from filter keytracking. May want different curve.
- **no smoothing:** amount applied instantly → changing while looping can click.
