### PR TITLE
Fix TS 7.0 tsconfig deprecation warnings

### DIFF
--- a/packages/audiolib/tsconfig.json
+++ b/packages/audiolib/tsconfig.json
@@ -2,13 +2,14 @@
 {
   "compilerOptions": {
     "strict": true,
+    "forceConsistentCasingInFileNames": true,
 
     "allowJs": true,
     "checkJs": false, // prevents type checking for JS files
 
     "target": "ES2022",
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable"], // ? , "WebWorker"], ?
 
     "declarationMap": true, // ?
@@ -27,7 +28,6 @@
 
     "declarationDir": "./dist",
     "outDir": "./dist",
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,6 +13,7 @@
     "moduleDetection": "force",
     "moduleResolution": "NodeNext",
     "noUncheckedIndexedAccess": true,
+    "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
Addresses deprecation warnings that will become errors in TypeScript 7.0. Config-only; TS is already at latest 5.9.3.

**audiolib/tsconfig.json**
- moduleResolution \`node\` -> \`bundler\` (matches how Vite actually resolves; tsc here only emits declarations)
- Removed deprecated \`baseUrl\` (\`paths\` resolves relative to tsconfig since TS 5.0 — \`@/*\` still works, verified)
- Added \`forceConsistentCasingInFileNames\`

**tsconfig.base.json**
- Added \`forceConsistentCasingInFileNames\`

Verified: \`tsc --emitDeclarationOnly\` passes clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved TypeScript configuration consistency across the project.
  * Added support for cleaner source path aliases in the audio library.
  * Enabled stricter filename casing checks to help prevent platform-specific build issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->