### PR TITLE
Remove legacy sampler element engine

### DIFF
--- a/apps/play/src/SIMPLIFICATION.md
+++ b/apps/play/src/SIMPLIFICATION.md
@@ -1,0 +1,29 @@
+# Recommended simplification order:
+
+### Remove the duplicate sampler engine first — high value / low effort.
+
+[ ] Sampler.ts still contains the old <sampler-element> lifecycle, localStorage restoration, WAV validation, event dispatch and disposal logic, while App actually uses createSampler(). Stop registering/maintaining the unused sampler-element engine and retain only the control registrations needed by the UI.
+
+### Replace the registry + global DOM-event + polling handshake with one explicit player handle — very high value / medium effort.
+
+[ ] The combination of target-node-id, nearest-parent lookup, SamplerRegistry, sampler-initialized, and retry intervals is the main inherited indirection. Introduce one app-level SamplePlayer reference/provider or a single readiness promise for the remaining vanilla controls. Keep DOM events only where an actual cross-component notification is required.
+
+### Unify sample persistence and loading — high value / low-medium effort.
+
+[ ] WAV encoding, base64 conversion, validation and currentSample persistence are duplicated between Sampler.ts and createSampler.ts. Move this into one small app service and have createSampler own the sample:loaded subscription.
+
+### Fix and simplify instrument-state persistence — high value / medium effort.
+
+[ ] instrumentState.ts still searches for retired wrapper tags such as volume-knob and sampler-element, while the app now renders ParamKnob and direct Solid controls. Saved samples can therefore miss knob/envelope state or fail to restore it. Capture state from the player/descriptor model and explicit control references instead of querying legacy DOM wrappers.
+
+### Make samplerParams the single parameter definition — high value / medium effort.
+
+[ ] ParamKnob already uses audiolib’s descriptors, but SamplerKnobFactory.ts still contains a second large set of parameter ranges, defaults, formatting and setter mappings. Migrate any remaining parameter controls to samplerParams, then delete the duplicate knob factory/configuration path.
+
+### Migrate remaining controls incrementally from custom elements to direct Solid components — high value / higher effort.
+
+[ ] Prioritize buttons, selects and toggles; leave the envelope editor/keyboard until later because they have the deepest VanJS and event dependencies. The goal is for controls to receive SamplePlayer directly and call its public API without target-node-id or document-level coordination.
+
+### Remove leftover compatibility surface after migration — medium value / low effort.
+
+[ ] Clean up stale global typings, commented-out element registrations, legacy instrumentState selectors, duplicated CSS/imports, and the historical extraction scaffolding once the above paths are no longer used.

--- a/apps/play/src/SIMPLIFICATION.md
+++ b/apps/play/src/SIMPLIFICATION.md
@@ -1,29 +1,29 @@
 # Recommended simplification order:
 
-### Remove the duplicate sampler engine first — high value / low effort.
+## Remove the duplicate sampler engine first — high value / low effort.
 
-[ ] Sampler.ts still contains the old <sampler-element> lifecycle, localStorage restoration, WAV validation, event dispatch and disposal logic, while App actually uses createSampler(). Stop registering/maintaining the unused sampler-element engine and retain only the control registrations needed by the UI.
+[x] Removed the unused <sampler-element> lifecycle from Sampler.ts. App now uses createSampler() as the sole SamplePlayer initialization path while retaining the remaining vanilla control registrations.
 
-### Replace the registry + global DOM-event + polling handshake with one explicit player handle — very high value / medium effort.
+## Replace the registry + global DOM-event + polling handshake with one explicit player handle — very high value / medium effort.
 
 [ ] The combination of target-node-id, nearest-parent lookup, SamplerRegistry, sampler-initialized, and retry intervals is the main inherited indirection. Introduce one app-level SamplePlayer reference/provider or a single readiness promise for the remaining vanilla controls. Keep DOM events only where an actual cross-component notification is required.
 
-### Unify sample persistence and loading — high value / low-medium effort.
+## Unify sample persistence and loading — high value / low-medium effort.
 
-[ ] WAV encoding, base64 conversion, validation and currentSample persistence are duplicated between Sampler.ts and createSampler.ts. Move this into one small app service and have createSampler own the sample:loaded subscription.
+[ ] createSampler still owns WAV encoding, base64 conversion, validation and currentSample persistence inline. Move this into one small app service and keep createSampler focused on player lifecycle and the sample:loaded subscription.
 
-### Fix and simplify instrument-state persistence — high value / medium effort.
+## Fix and simplify instrument-state persistence — high value / medium effort.
 
 [ ] instrumentState.ts still searches for retired wrapper tags such as volume-knob and sampler-element, while the app now renders ParamKnob and direct Solid controls. Saved samples can therefore miss knob/envelope state or fail to restore it. Capture state from the player/descriptor model and explicit control references instead of querying legacy DOM wrappers.
 
-### Make samplerParams the single parameter definition — high value / medium effort.
+## Make samplerParams the single parameter definition — high value / medium effort.
 
 [ ] ParamKnob already uses audiolib’s descriptors, but SamplerKnobFactory.ts still contains a second large set of parameter ranges, defaults, formatting and setter mappings. Migrate any remaining parameter controls to samplerParams, then delete the duplicate knob factory/configuration path.
 
-### Migrate remaining controls incrementally from custom elements to direct Solid components — high value / higher effort.
+## Migrate remaining controls incrementally from custom elements to direct Solid components — high value / higher effort.
 
 [ ] Prioritize buttons, selects and toggles; leave the envelope editor/keyboard until later because they have the deepest VanJS and event dependencies. The goal is for controls to receive SamplePlayer directly and call its public API without target-node-id or document-level coordination.
 
-### Remove leftover compatibility surface after migration — medium value / low effort.
+## Remove leftover compatibility surface after migration — medium value / low effort.
 
 [ ] Clean up stale global typings, commented-out element registrations, legacy instrumentState selectors, duplicated CSS/imports, and the historical extraction scaffolding once the above paths are no longer used.

--- a/apps/play/src/audio-elements/elements/Sampler/Sampler.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/Sampler.ts
@@ -1,11 +1,4 @@
-// Sampler.ts
-import van, { State } from '@repo/vanjs-core';
-import { define, ElementProps } from '@repo/vanjs-core/element';
-import { SamplePlayer, createSamplePlayer } from '@repo/audiolib';
-
-import { registerSampler, unregisterSampler } from './SamplerRegistry';
-
-import { COMPONENT_STYLE } from '../../shared/styles/component-styles';
+import { define } from '@repo/vanjs-core/element';
 
 import {
   DryWetKnob,
@@ -69,299 +62,7 @@ import {
 import { AMModulation } from './components/AMModulation';
 import { SamplerStatusElement } from './components/SamplerStatusElement';
 
-const { div } = van.tags;
-
-// Utility: Encode AudioBuffer as WAV (PCM 16-bit LE)
-function audioBufferToWav(buffer: AudioBuffer): ArrayBuffer {
-  const numChannels = buffer.numberOfChannels;
-  const sampleRate = buffer.sampleRate;
-  const length = buffer.length;
-  const bytesPerSample = 2; // 16-bit PCM
-  const blockAlign = numChannels * bytesPerSample;
-  const byteRate = sampleRate * blockAlign;
-  const dataSize = length * blockAlign;
-  const bufferSize = 44 + dataSize;
-  const wavBuffer = new ArrayBuffer(bufferSize);
-  const view = new DataView(wavBuffer);
-
-  // RIFF header
-  let offset = 0;
-  function writeString(str: string) {
-    for (let i = 0; i < str.length; i++) {
-      view.setUint8(offset++, str.charCodeAt(i));
-    }
-  }
-  writeString('RIFF');
-  view.setUint32(offset, 36 + dataSize, true);
-  offset += 4;
-  writeString('WAVE');
-  writeString('fmt ');
-  view.setUint32(offset, 16, true);
-  offset += 4; // PCM chunk size
-  view.setUint16(offset, 1, true);
-  offset += 2; // PCM format
-  view.setUint16(offset, numChannels, true);
-  offset += 2;
-  view.setUint32(offset, sampleRate, true);
-  offset += 4;
-  view.setUint32(offset, byteRate, true);
-  offset += 4;
-  view.setUint16(offset, blockAlign, true);
-  offset += 2;
-  view.setUint16(offset, 16, true);
-  offset += 2; // bits per sample
-  writeString('data');
-  view.setUint32(offset, dataSize, true);
-  offset += 4;
-
-  // Write PCM samples
-  for (let i = 0; i < length; i++) {
-    for (let ch = 0; ch < numChannels; ch++) {
-      let sample = buffer.getChannelData(ch)[i];
-      // Clamp and convert to 16-bit PCM
-      sample = Math.max(-1, Math.min(1, sample));
-
-      const pcmSample = Math.round(sample * 32767);
-      view.setInt16(offset, pcmSample, true);
-      offset += 2;
-    }
-  }
-
-  return wavBuffer;
-}
-
-function arrayBufferToBase64(buffer: ArrayBuffer) {
-  let binary = '';
-  const bytes = new Uint8Array(buffer);
-  const len = bytes.byteLength;
-  for (let i = 0; i < len; i++) {
-    binary += String.fromCharCode(bytes[i]);
-  }
-  return btoa(binary); // encode as base64
-}
-
-function base64ToArrayBuffer(base64: string): ArrayBuffer {
-  const binary: string = atob(base64);
-  const len: number = binary.length;
-  const buffer: ArrayBuffer = new ArrayBuffer(len);
-  const bytes: Uint8Array = new Uint8Array(buffer);
-  for (let i = 0; i < len; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return buffer;
-}
-
-function isWav(arrayBuffer: ArrayBuffer) {
-  // Check for WAV header: 'RIFF' at 0, 'WAVE' at 8
-  const header = new Uint8Array(arrayBuffer);
-  const isWav =
-    header[0] === 0x52 && // 'R'
-    header[1] === 0x49 && // 'I'
-    header[2] === 0x46 && // 'F'
-    header[3] === 0x46 && // 'F'
-    header[8] === 0x57 && // 'W'
-    header[9] === 0x41 && // 'A'
-    header[10] === 0x56 && // 'V'
-    header[11] === 0x45; // 'E'
-
-  return isWav;
-}
-
-// TEMP fix to avoid loading corrupted samples from localStorage (happens in Brave browser)
-function validateWavBuffer(buffer: ArrayBuffer): boolean {
-  if (buffer.byteLength < 44) return false; // Minimum WAV header size
-
-  if (!isWav(buffer)) return false;
-
-  const view = new DataView(buffer);
-
-  // check if is at least 0.2 seconds and has non-zero data
-  const sampleRate = view.getUint32(24, true);
-  const numChannels = view.getUint16(22, true);
-  const bitsPerSample = view.getUint16(34, true);
-  const byteRate = sampleRate * numChannels * (bitsPerSample / 8);
-  const dataSize = view.getUint32(40, true);
-  const durationSeconds = dataSize / byteRate;
-
-  if (durationSeconds < 0.2 || dataSize === 0) return false;
-
-  // Quick health check for amplitude
-  const dataOffset = 44; // Standard WAV header size
-  const sampleSize = bitsPerSample / 8;
-  const numSamples = Math.floor((buffer.byteLength - dataOffset) / sampleSize);
-
-  let sumAbs = 0;
-  const samplesToCheck = Math.min(1000, numSamples);
-  for (let i = 0; i < samplesToCheck; i++) {
-    const sampleIndex = Math.floor((i * numSamples) / samplesToCheck);
-    let sample;
-    if (bitsPerSample === 16) {
-      sample = view.getInt16(dataOffset + sampleIndex * sampleSize, true);
-    } else if (bitsPerSample === 8) {
-      sample = view.getInt8(dataOffset + sampleIndex * sampleSize);
-    } else {
-      continue;
-    }
-    sumAbs += Math.abs(sample);
-  }
-  const avgAbs = sumAbs / samplesToCheck;
-  const threshold = 0.08 * (1 << (bitsPerSample - 1));
-
-  if (avgAbs < threshold) return false;
-
-  return true;
-}
-
-export interface SamplerElement extends HTMLElement {
-  nodeId: string;
-  getSamplePlayer: () => SamplePlayer | null;
-  getSampleBuffer: () => AudioBuffer | null;
-}
-
-// ===== SAMPLER ENGINE =====
-export const SamplerElement = (attributes: ElementProps) => {
-  let samplePlayer: SamplePlayer | null = null;
-
-  const nodeId: State<string> = attributes.attr('node-id', '');
-  const polyphony = attributes.attr('polyphony', '16');
-  const debugMode = attributes.attr('debug-mode', 'false');
-  const status = van.state('Click to start');
-
-  attributes.mount(() => {
-    let disposed = false;
-
-    const initializeAudio = async () => {
-      try {
-        let initSample = undefined;
-        const storedBuffer = localStorage.getItem('currentSample');
-
-        if (storedBuffer?.length) {
-          const arrayBuffer = base64ToArrayBuffer(storedBuffer);
-
-          if (validateWavBuffer(arrayBuffer)) {
-            initSample = arrayBuffer;
-          }
-        }
-
-        const initializedSamplePlayer = await createSamplePlayer(
-          initSample,
-          parseInt(polyphony.val),
-        );
-
-        if (disposed) {
-          initializedSamplePlayer.dispose();
-          return;
-        }
-
-        samplePlayer = initializedSamplePlayer;
-
-        if (!nodeId.val) {
-          nodeId.val = samplePlayer.nodeId;
-        }
-
-        registerSampler(nodeId.val, samplePlayer);
-
-        document.dispatchEvent(
-          new CustomEvent('sampler-initialized', {
-            detail: { nodeId: nodeId.val },
-          }),
-        );
-
-        status.val = 'Initialized';
-
-        samplePlayer.onMessage('sample:loaded', (msg: any) => {
-          status.val = 'Loaded';
-          const audiobuffer = samplePlayer?.audiobuffer;
-
-          document.dispatchEvent(
-            new CustomEvent('sample-loaded', {
-              detail: {
-                nodeId: nodeId.val,
-                buffer: audiobuffer,
-                durationSeconds: msg.durationSeconds,
-              },
-            }),
-          );
-          if (audiobuffer?.length) {
-            // Store as WAV for compatibility with decodeAudioData
-            const wavBuffer = audioBufferToWav(audiobuffer);
-            const base64buffer = arrayBufferToBase64(wavBuffer);
-            try {
-              localStorage.setItem('currentSample', base64buffer);
-            } catch (error) {
-              console.warn('Failed to persist sample to localStorage:', error);
-            }
-          }
-        });
-
-        Object.assign(attributes.$this, {
-          nodeId: nodeId.val,
-          getSamplePlayer: () => samplePlayer,
-          getSampleBuffer: () => samplePlayer?.audiobuffer || null,
-        });
-      } catch (error: any) {
-        console.error('Sampler initialization error:', error);
-        if (error?.message?.includes('AudioWorklet')) {
-          status.val = 'Browser not supported';
-          document.dispatchEvent(
-            new CustomEvent('sampler-error', {
-              detail: {
-                nodeId: nodeId.val,
-                error: 'AudioWorklet not supported',
-                message:
-                  'This browser does not fully support Web Audio. Please use Chrome, Firefox, or Edge on desktop, or update your mobile browser.',
-              },
-            }),
-          );
-        } else {
-          const errText =
-            typeof error?.message === 'string' ? error.message : String(error);
-          status.val = `Error: ${errText}`;
-          document.dispatchEvent(
-            new CustomEvent('sampler-error', {
-              detail: {
-                nodeId: nodeId.val,
-                error: errText,
-              },
-            }),
-          );
-        }
-      }
-    };
-
-    initializeAudio();
-
-    return () => {
-      disposed = true;
-      if (samplePlayer && nodeId.val) {
-        unregisterSampler(nodeId.val);
-        samplePlayer.dispose();
-      }
-    };
-  });
-
-  // Render debug information, only if debug-mode attribute is present
-  if (debugMode.val === 'true' || debugMode.val === '') {
-    return div(
-      {
-        'node-id': () => nodeId.val,
-        style: `${COMPONENT_STYLE}`,
-      },
-      div(() => `Sampler: ${nodeId.val}`),
-      div(() => `Status: ${status.val}`),
-    );
-  }
-
-  // Return invisible element
-  return div({
-    'node-id': () => nodeId.val,
-    style: 'display: none;',
-  });
-};
-
-// ===== EXPORT ALL COMPONENTS =====
 export {
-  // Knob components
   DryWetKnob,
   FeedbackKnob,
   DriveKnob,
@@ -391,8 +92,6 @@ export {
   DelayTimeKnob,
   DelayFeedbackKnob,
   TempoKnob,
-
-  // Toggle components
   FeedbackModeToggle,
   MidiToggle,
   LoopLockToggle,
@@ -402,83 +101,32 @@ export {
   PlaybackDirectionToggle,
   PanDriftToggle,
   PitchToggle,
-
-  // Control components
   ComputerKeyboard,
   PianoKeyboard,
   RecordButton,
   UploadButton,
   SaveButton,
-
-  // Select components
   KeymapSelect,
   WaveformSelect,
   InputSourceSelect,
   RootNoteSelect,
-
-  // Composite components
   AMModulation,
-
-  // Status display
   SamplerStatusElement,
-
-  // Envelopes
   EnvelopeDisplay,
 };
 
-// ===== REGISTRATION =====
 const defineIfNotExists = (name: string, elementFunc: any, options: any) => {
   if (!customElements.get(name)) {
     define(name, elementFunc, options);
   }
 };
 
-/* NOTE!
-  Phasing out audio-components:
-  commenting out already-migrated elements (and leaving rest of audio-components as is),
-  until all done.
-  */
-
+/** Register the remaining app-local vanilla controls. */
 export const defineSampler = () => {
-  // Core sampler
-  defineIfNotExists('sampler-element', SamplerElement, false);
-
-  // Basic controls
   defineIfNotExists('load-button', UploadButton, false);
   defineIfNotExists('record-button', RecordButton, false);
   defineIfNotExists('save-button', SaveButton, false);
 
-  // defineIfNotExists('volume-knob', VolumeKnob, false);
-  // defineIfNotExists('reverb-send-knob', ReverbSendKnob, false);
-  // defineIfNotExists('reverb-size-knob', ReverbSizeKnob, false);
-  // defineIfNotExists('lowpass-filter-knob', LowpassFilterKnob, false);
-  // defineIfNotExists('highpass-filter-knob', HighpassFilterKnob, false);
-  // defineIfNotExists('dry-wet-knob', DryWetKnob, false);
-  // defineIfNotExists('feedback-knob', FeedbackKnob, false);
-  // defineIfNotExists('drive-knob', DriveKnob, false);
-  // defineIfNotExists('clipping-knob', ClippingKnob, false);
-  // defineIfNotExists('glide-knob', GlideKnob, false);
-  // defineIfNotExists('feedback-pitch-knob', FeedbackPitchKnob, false);
-  // defineIfNotExists('feedback-decay-knob', FeedbackDecayKnob, false);
-  // defineIfNotExists('feedback-lpf-knob', FeedbackLpfKnob, false);
-  // defineIfNotExists('gain-lfo-rate-knob', GainLFORateKnob, false);
-  // defineIfNotExists('gain-lfo-depth-knob', GainLFODepthKnob, false);
-  // defineIfNotExists('pitch-lfo-rate-knob', PitchLFORateKnob, false);
-  // defineIfNotExists('pitch-lfo-depth-knob', PitchLFODepthKnob, false);
-  // defineIfNotExists('am-mod-knob', AMModKnob, false);
-  // defineIfNotExists('loop-start-knob', LoopStartKnob, false);
-  // defineIfNotExists('loop-duration-knob', LoopDurationKnob, false);
-  // defineIfNotExists('loop-duration-drift-knob', LoopDurationDriftKnob, false);
-  // defineIfNotExists('keytrack-loop-knob', KeytrackLoopKnob, false);
-  // defineIfNotExists('trim-start-knob', TrimStartKnob, false);
-  // defineIfNotExists('trim-end-knob', TrimEndKnob, false);
-  // defineIfNotExists('distortion-knob', DistortionKnob, false);
-  // defineIfNotExists('delay-send-knob', DelaySendKnob, false);
-  // defineIfNotExists('delay-time-knob', DelayTimeKnob, false);
-  // defineIfNotExists('delay-feedback-knob', DelayFeedbackKnob, false);
-  // defineIfNotExists('tempo-knob', TempoKnob, false);
-
-  // Toggle controls
   defineIfNotExists('feedback-mode-toggle', FeedbackModeToggle, false);
   defineIfNotExists('midi-toggle', MidiToggle, false);
   defineIfNotExists('loop-lock-toggle', LoopLockToggle, false);
@@ -493,25 +141,17 @@ export const defineSampler = () => {
   defineIfNotExists('pan-drift-toggle', PanDriftToggle, false);
   defineIfNotExists('pitch-toggle', PitchToggle, false);
 
-  // Envelopes
   defineIfNotExists('envelope-display', EnvelopeDisplay, false);
   defineIfNotExists('envelope-switcher', EnvelopeSwitcher, false);
 
-  // Input controls
   defineIfNotExists('computer-keyboard', ComputerKeyboard, false);
   defineIfNotExists('piano-keyboard', PianoKeyboard, false);
 
-  // Select controls
   defineIfNotExists('keymap-select', KeymapSelect, false);
   defineIfNotExists('waveform-select', WaveformSelect, false);
   defineIfNotExists('input-select', InputSourceSelect, false);
   defineIfNotExists('rootnote-select', RootNoteSelect, false);
 
-  // Composite controls
   defineIfNotExists('am-modulation', AMModulation, false);
-
-  // Status display
   defineIfNotExists('sampler-status', SamplerStatusElement, false);
 };
-
-defineSampler();

--- a/apps/play/src/main.tsx
+++ b/apps/play/src/main.tsx
@@ -8,7 +8,7 @@ import './styles/themes.css';
 import './style.css';
 import './utils/pwa-utils/updateSW';
 
-defineSampler(); // Define all web components for the sampler
+defineSampler(); // Define the remaining vanilla controls
 
 const root = document.getElementById('root');
 

--- a/apps/play/src/types/global.d.ts
+++ b/apps/play/src/types/global.d.ts
@@ -10,9 +10,6 @@ declare module 'solid-js' {
   }
   namespace JSX {
     interface IntrinsicElements {
-      // Sampler core
-      'sampler-element': any;
-
       // Envelope components
       'envelope-switcher': any;
       'envelope-display': any;


### PR DESCRIPTION
## Summary
- remove the unused `<sampler-element>` SamplePlayer lifecycle from `apps/play`
- keep `createSampler()` as the app's sole SamplePlayer initialization path
- retain registration of the remaining vanilla controls and remove the obsolete JSX type declaration

## Design decision
The app already creates and owns its `SamplePlayer` through `createSampler()` in `App.tsx`; no `<sampler-element>` is rendered. This change removes only the duplicate engine and its localStorage/WAV/event/disposal implementation. The remaining controls, registry, and compatibility DOM events are intentionally unchanged so manual behavior should remain the same.

## Verification
- `pnpm --filter play exec tsc --noEmit`
- `pnpm --filter play build`

Manual browser verification is still recommended for the play app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a step-by-step guide for simplifying and cleaning up the app’s sampler architecture.

* **Refactor**
  * Streamlined how sampler controls are registered and initialized, reducing legacy/duplicate wiring.
  * Updated the app’s setup messaging to reflect the simplified “remaining vanilla controls” approach.

* **Type Updates**
  * Removed the generic custom intrinsic typing for the sampler element to better match current usage.

* **Maintenance**
  * Improved consistency of sampler control initialization without changing the public feature set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->