### PR TITLE
Simplify registry + handshake with single player instance

### DIFF
--- a/apps/play/src/App.tsx
+++ b/apps/play/src/App.tsx
@@ -85,6 +85,11 @@ const App: Component = () => {
         samplerRef = sampler;
         samplePlayerRef = sampler.samplePlayer;
         setSamplePlayer(sampler.samplePlayer);
+        document.dispatchEvent(
+          new CustomEvent('sampler-initialized', {
+            detail: { nodeId: sampler.nodeId },
+          }),
+        );
       })
       .catch(() => {
         // Errors already logged and dispatched as 'sampler-error' by createSampler

--- a/apps/play/src/App.tsx
+++ b/apps/play/src/App.tsx
@@ -32,17 +32,16 @@ import RowCollapseIcons from './components/RowCollapseIcons';
 import OutputDeviceSelect from './components/OutputDeviceSelect';
 import InputDeviceSelect from './components/InputDeviceSelect';
 
-let samplePlayerRef: SamplePlayer | null = null;
+export const [samplePlayer, setSamplePlayer] = createSignal<SamplePlayer | null>(
+  null,
+);
 
-export const getSamplePlayer = () => samplePlayerRef;
+// Untracked read for non-reactive consumers (web components, MidiMan, etc.)
+export const getSamplePlayer = () => samplePlayer();
 
 const App: Component = () => {
   const [layout, setLayout] = createSignal<LayoutType>('desktop');
   const [envHeight, setEnvHeight] = createSignal<number>(225);
-
-  const [samplePlayer, setSamplePlayer] = createSignal<SamplePlayer | null>(
-    null,
-  );
 
   const [currentAudioBuffer, setCurrentAudioBuffer] =
     createSignal<AudioBuffer | null>(null);
@@ -66,11 +65,9 @@ const App: Component = () => {
   };
 
   const { handleSampleSelect } = useSampleSelection(
-    () => samplePlayerRef,
+    getSamplePlayer,
     setSidebarOpen,
   );
-
-  const getSamplePlayer = () => samplePlayerRef;
 
   onMount(() => {
     let disposed = false;
@@ -81,7 +78,6 @@ const App: Component = () => {
           sampler.dispose();
           return;
         }
-        samplePlayerRef = sampler.samplePlayer;
         setSamplePlayer(sampler.samplePlayer);
         document.dispatchEvent(
           new CustomEvent('sampler-initialized', {
@@ -94,17 +90,17 @@ const App: Component = () => {
       });
 
     const handleSampleLoaded = () => {
-      const audiobuffer = samplePlayerRef?.audiobuffer || null;
+      const audiobuffer = getSamplePlayer()?.audiobuffer || null;
 
       setCurrentAudioBuffer(audiobuffer);
       setSampleLoaded(true);
       // Preserve a device chosen before the player was ready
       const chosenDeviceId = selectedInputDeviceId();
       if (chosenDeviceId) {
-        samplePlayerRef?.setRecorderInputDeviceId(chosenDeviceId);
+        getSamplePlayer()?.setRecorderInputDeviceId(chosenDeviceId);
       } else {
         setSelectedInputDeviceId(
-          samplePlayerRef?.getRecorderInputDeviceId() || '',
+          getSamplePlayer()?.getRecorderInputDeviceId() || '',
         );
       }
     };
@@ -137,7 +133,7 @@ const App: Component = () => {
     document.addEventListener('sample-loaded', handleSampleLoaded);
 
     enableSamplePlayerMidi({
-      getSamplePlayer: () => samplePlayerRef,
+      getSamplePlayer,
       enableKnobMidi: true,
       midiLearnEnabled: true,
       knobMappings: [
@@ -414,7 +410,7 @@ const App: Component = () => {
                 displayValue={true}
                 size={45}
                 onChange={(detail: KnobChangeEventDetail) =>
-                  samplePlayerRef?.setHpfCutoff(detail.value)
+                  getSamplePlayer()?.setHpfCutoff(detail.value)
                 }
               />
               <KnobComponent
@@ -422,7 +418,7 @@ const App: Component = () => {
                 displayValue={true}
                 size={45}
                 onChange={(detail: KnobChangeEventDetail) =>
-                  samplePlayerRef?.setLpfCutoff(detail.value)
+                  getSamplePlayer()?.setLpfCutoff(detail.value)
                 }
               /> */}
             </div>
@@ -606,14 +602,14 @@ export default App;
 //   if (e.code === 'IntlBackslash') {
 //     e.preventDefault();
 //     console.log('Freezing active voices');
-//     samplePlayerRef?.freezeActiveVoices(true);
+//     getSamplePlayer()?.freezeActiveVoices(true);
 //   }
 // });
 // document.body.addEventListener('keyup', (e) => {
 //   if (e.code === 'IntlBackslash') {
 //     e.preventDefault();
 //     console.log('Unfreezing active voices');
-//     samplePlayerRef?.freezeActiveVoices(false);
+//     getSamplePlayer()?.freezeActiveVoices(false);
 //   }
 // });
 // ! END - TEST Listener

--- a/apps/play/src/App.tsx
+++ b/apps/play/src/App.tsx
@@ -32,12 +32,15 @@ import RowCollapseIcons from './components/RowCollapseIcons';
 import OutputDeviceSelect from './components/OutputDeviceSelect';
 import InputDeviceSelect from './components/InputDeviceSelect';
 
+let samplePlayerRef: SamplePlayer | null = null;
+
+export const getSamplePlayer = () => samplePlayerRef;
+
 const App: Component = () => {
   const [layout, setLayout] = createSignal<LayoutType>('desktop');
   const [envHeight, setEnvHeight] = createSignal<number>(225);
 
   let samplerRef: Sampler | undefined;
-  let samplePlayerRef: SamplePlayer | null = null;
   const [samplePlayer, setSamplePlayer] = createSignal<SamplePlayer | null>(
     null,
   );

--- a/apps/play/src/App.tsx
+++ b/apps/play/src/App.tsx
@@ -71,6 +71,7 @@ const App: Component = () => {
 
   onMount(() => {
     let disposed = false;
+    let samplerHandle: Sampler | undefined;
 
     createSampler({ nodeId: 'test-sampler' })
       .then((sampler) => {
@@ -78,6 +79,7 @@ const App: Component = () => {
           sampler.dispose();
           return;
         }
+        samplerHandle = sampler;
         setSamplePlayer(sampler.samplePlayer);
         document.dispatchEvent(
           new CustomEvent('sampler-initialized', {
@@ -177,6 +179,11 @@ const App: Component = () => {
 
       cleanupNotifications();
       disableSamplePlayerMidi();
+
+      if (samplerHandle) {
+        samplerHandle.dispose();
+        setSamplePlayer(null);
+      }
     });
   });
 

--- a/apps/play/src/App.tsx
+++ b/apps/play/src/App.tsx
@@ -40,7 +40,6 @@ const App: Component = () => {
   const [layout, setLayout] = createSignal<LayoutType>('desktop');
   const [envHeight, setEnvHeight] = createSignal<number>(225);
 
-  let samplerRef: Sampler | undefined;
   const [samplePlayer, setSamplePlayer] = createSignal<SamplePlayer | null>(
     null,
   );
@@ -82,7 +81,6 @@ const App: Component = () => {
           sampler.dispose();
           return;
         }
-        samplerRef = sampler;
         samplePlayerRef = sampler.samplePlayer;
         setSamplePlayer(sampler.samplePlayer);
         document.dispatchEvent(
@@ -183,7 +181,6 @@ const App: Component = () => {
 
       cleanupNotifications();
       disableSamplePlayerMidi();
-      samplerRef?.dispose();
     });
   });
 

--- a/apps/play/src/SIMPLIFICATION.md
+++ b/apps/play/src/SIMPLIFICATION.md
@@ -6,7 +6,7 @@
 
 ## Replace the registry + global DOM-event + polling handshake with one explicit player handle — very high value / medium effort.
 
-[x] Replaced registry lookup with a single app-level `__samplePlayerInstance` global. Removed 100ms polling intervals and simplified connection handlers. Vanilla controls now import `getSamplePlayerInstance()` directly from component-utils instead of doing target-node-id lookup → registry → retry. Kept `sampler-initialized` event for readiness signaling only, removed unused registry change callbacks.
+[x] Replaced registry lookup with a single module-scoped SolidJS signal in App.tsx. Vanilla controls import `getSamplePlayer()` directly from App.tsx (an untracked read of the signal) instead of doing target-node-id lookup → registry → retry. Removed 100ms polling intervals; kept `sampler-initialized` (now dispatched only after the signal is set) as the one readiness signal. Also disposed of dead `target-node-id` readiness gating left over from the registry in ComputerKeyboard/PianoKeyboard/EnvelopeDisplay/EnvelopeSwitcher, and restored sampler disposal on App unmount (dropped by mistake during registry cleanup).
 
 ## Unify sample persistence and loading — high value / low-medium effort.
 
@@ -26,4 +26,4 @@
 
 ## Remove leftover compatibility surface after migration — medium value / low effort.
 
-[ ] Clean up stale global typings, commented-out element registrations, legacy instrumentState selectors, duplicated CSS/imports, and the historical extraction scaffolding once the above paths are no longer used.
+[ ] Clean up stale global typings, commented-out element registrations, legacy instrumentState selectors, duplicated CSS/imports, and the historical extraction scaffolding once the above paths are no longer used. Known instances: unused `target-node-id` declarations in SamplerToggleFactory.ts (5x) and AMModulation.ts; large commented-out legacy implementation in EnvelopeDisplay.ts.

--- a/apps/play/src/SIMPLIFICATION.md
+++ b/apps/play/src/SIMPLIFICATION.md
@@ -6,7 +6,7 @@
 
 ## Replace the registry + global DOM-event + polling handshake with one explicit player handle — very high value / medium effort.
 
-[ ] The combination of target-node-id, nearest-parent lookup, SamplerRegistry, sampler-initialized, and retry intervals is the main inherited indirection. Introduce one app-level SamplePlayer reference/provider or a single readiness promise for the remaining vanilla controls. Keep DOM events only where an actual cross-component notification is required.
+[x] Replaced registry lookup with a single app-level `__samplePlayerInstance` global. Removed 100ms polling intervals and simplified connection handlers. Vanilla controls now import `getSamplePlayerInstance()` directly from component-utils instead of doing target-node-id lookup → registry → retry. Kept `sampler-initialized` event for readiness signaling only, removed unused registry change callbacks.
 
 ## Unify sample persistence and loading — high value / low-medium effort.
 

--- a/apps/play/src/audio-elements/elements/Sampler/component-utils.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/component-utils.ts
@@ -5,79 +5,52 @@ import { ElementProps } from '@repo/vanjs-core/element';
 import { createKnob, KnobConfig } from '@/elements/primitives/createKnob';
 import { INLINE_COMPONENT_STYLE } from '../../shared/styles/component-styles';
 
+export const getSamplePlayerInstance = (): SamplePlayer | null => {
+  return (window as any).__samplePlayerInstance || null;
+};
+
 const { div } = van.tags;
 
-/**
- * Find the target node ID for a component.
- * Follows the priority: explicit target-node-id > parent sampler > nearest sampler
- */
-export const findNodeId =
-  (attributes: ElementProps, targetNodeId: State<string>) => () => {
-    if (targetNodeId.val) return targetNodeId.val;
-
-    // Find parent sampler-element
-    const parent = attributes.$this.closest('sampler-element') as any;
-    if (parent?.nodeId) return parent.nodeId;
-
-    // Find nearest sampler-element and check both nodeId property and node-id attribute
-    const nearest = document.querySelector('sampler-element') as any;
-    if (nearest?.nodeId) return nearest.nodeId;
-
-    // Fallback to node-id attribute
-    return nearest?.getAttribute('node-id') || '';
-  };
 
 /**
  * Creates a reusable connection handler for sampler components
  */
 export const createSamplerConnection = (
-  findNodeId: () => string,
-  getSampler: (nodeId: string) => any,
   onConnect: (sampler: SamplePlayer) => void
 ) => {
   let connected = false;
 
   const connect = () => {
     if (connected) return;
-    const nodeId = findNodeId();
-    if (!nodeId) return;
-    const sampler = getSampler(nodeId);
+    const sampler = getSamplePlayerInstance();
     if (sampler) {
       connected = true;
       onConnect(sampler);
     }
   };
 
-  const createMountHandler = (attributes: ElementProps) => {
+  const createMountHandler = () => {
     return () => {
       // Try to connect immediately
       connect();
 
-      // Listen for sampler-initialized events
-      const handleSamplerInitialized = (e: CustomEvent) => {
-        if (e.detail.nodeId === findNodeId()) connect();
-      };
-      document.addEventListener(
-        'sampler-initialized',
-        handleSamplerInitialized as EventListener
-      );
-
-      // Also try connecting periodically for timing issues
-      const interval = setInterval(() => {
-        if (connected) {
-          clearInterval(interval);
-          return;
-        }
-        connect();
-      }, 100);
-
-      return () => {
-        document.removeEventListener(
+      // If not yet available, listen for sampler-initialized
+      if (!connected) {
+        const handleSamplerInitialized = () => {
+          connect();
+        };
+        document.addEventListener(
           'sampler-initialized',
           handleSamplerInitialized as EventListener
         );
-        clearInterval(interval);
-      };
+
+        return () => {
+          document.removeEventListener(
+            'sampler-initialized',
+            handleSamplerInitialized as EventListener
+          );
+        };
+      }
     };
   };
 
@@ -102,7 +75,6 @@ export interface ToggleConfig {
  */
 export const createToggleForTarget = (
   config: ToggleConfig,
-  getTargetNode: (nodeId: string) => any,
   Toggle: any,
   van: any,
   componentStyle?: string
@@ -110,17 +82,12 @@ export const createToggleForTarget = (
   const { div } = van.tags;
 
   return (attributes: ElementProps) => {
-    const targetNodeId: State<string> = attributes.attr('target-node-id', '');
     const toggleState = van.state(config.defaultValue);
     let connected = false;
 
-    const findId = findNodeId(attributes, targetNodeId);
-
     const connect = () => {
       if (connected) return;
-      const nodeId = findId();
-      if (!nodeId) return;
-      const sampler = getTargetNode(nodeId);
+      const sampler = getSamplePlayerInstance();
       if (sampler) {
         connected = true;
         config.onSamplerConnect?.(sampler, toggleState, van);
@@ -129,28 +96,21 @@ export const createToggleForTarget = (
 
     attributes.mount(() => {
       connect();
-      const handleInitialized = (e: CustomEvent) => {
-        if (e.detail.nodeId === findId()) connect();
-      };
-      document.addEventListener(
-        'sampler-initialized',
-        handleInitialized as EventListener
-      );
-      return () =>
-        document.removeEventListener(
+      if (!connected) {
+        const handleInitialized = () => {
+          connect();
+        };
+        document.addEventListener(
           'sampler-initialized',
           handleInitialized as EventListener
         );
+        return () =>
+          document.removeEventListener(
+            'sampler-initialized',
+            handleInitialized as EventListener
+          );
+      }
     });
-
-    // // Check if label attribute was explicitly provided (even if empty)
-    // const hasLabelAttribute = attributes.$this.hasAttribute('label');
-    // const labelOverride = hasLabelAttribute
-    //   ? attributes.$this.getAttribute('label')
-    //   : null;
-
-    // // Use label attribute if provided (including empty string), otherwise fall back to config label
-    // const effectiveLabel = hasLabelAttribute ? labelOverride : config.label;
 
     return div(
       {
@@ -170,13 +130,9 @@ export const createToggleForTarget = (
 };
 
 export const createKnobForTarget = (
-  config: KnobConfig,
-  getTarget: (nodeId: string) => SamplePlayer | null
+  config: KnobConfig
 ) => {
   return (attributes: ElementProps) => {
-    const targetNodeId = attributes.attr('target-node-id', '');
-    const findId = findNodeId(attributes, targetNodeId);
-
     // Initialize state with default value
     const state = van.state(config.defaultValue ?? 0);
 
@@ -192,124 +148,58 @@ export const createKnobForTarget = (
 
     let connected = false;
     let knobContainer: HTMLElement | null = null;
-    let isInitializing = true; // Flag to prevent saving during initialization
-
-    // Storage functions
-    const getStorageKey = (nodeId: string) => {
-      const key = config.paramName || config.label || 'unknown';
-      return `${key}:nodeId:${nodeId}`;
-    };
-
-    const loadStoredValue = (nodeId: string) => {
-      if (!config.useLocalStorage || !nodeId) return false;
-
-      const storageKey = getStorageKey(nodeId);
-      const stored = localStorage.getItem(storageKey);
-
-      if (stored) {
-        const parsed = parseFloat(stored);
-        if (!isNaN(parsed)) {
-          state.val = parsed;
-
-          // Update the knob element
-          const knobElement = knobContainer?.querySelector(
-            'knob-element'
-          ) as any;
-          if (knobElement?.setValue) {
-            knobElement.setValue(parsed);
-          }
-
-          return true;
-        }
-      }
-      return false;
-    };
-
-    const saveValue = (value: number, nodeId: string) => {
-      if (!config.useLocalStorage || !nodeId || isInitializing) {
-        return;
-      }
-
-      try {
-        const storageKey = getStorageKey(nodeId);
-        localStorage.setItem(storageKey, String(value));
-      } catch (error) {
-        console.warn('Failed to save knob value to localStorage:', error);
-      }
-    };
+    let isInitializing = true;
 
     const connect = () => {
       if (connected) return;
-      const nodeId = findId();
-
-      if (!nodeId) {
-        console.debug('❌ No nodeId found, cannot connect');
-        return;
-      }
-
-      const target = getTarget(nodeId);
+      const target = getSamplePlayerInstance();
 
       if (target) {
-        // Load stored value BEFORE connecting
-        loadStoredValue(nodeId);
-
         connected = true;
 
         const knobElement = knobContainer?.querySelector('knob-element');
         config.onConnect?.(target, state, knobElement);
 
-        // Now that we're connected, allow saving
         setTimeout(() => {
           isInitializing = false;
         }, 100);
-      } else {
-        // console.debug('❌ Target not found for nodeId:', nodeId);
       }
     };
 
-    // Mount debugic
     attributes.mount(() => {
       connect();
-
-      const handleInit = (e: CustomEvent) => {
-        if (e.detail.nodeId === findId()) {
+      if (!connected) {
+        const handleInit = () => {
           connect();
-        }
-      };
+        };
 
-      document.addEventListener(
-        'sampler-initialized',
-        handleInit as EventListener
-      );
-
-      return () => {
-        document.removeEventListener(
+        document.addEventListener(
           'sampler-initialized',
           handleInit as EventListener
         );
-      };
+
+        return () => {
+          document.removeEventListener(
+            'sampler-initialized',
+            handleInit as EventListener
+          );
+        };
+      }
     });
 
-    // Create knob with simplified config - NO internal storage handling
+    // Create knob with simplified config
     knobContainer = createKnob(
       {
         ...config,
         label: effectiveLabel,
-        useLocalStorage: false, // Disable internal storage
+        useLocalStorage: false,
         state,
         onChange: (value) => {
           state.val = value;
-
-          // Save to storage ourselves (but not during initialization)
-          const nodeId = findId();
-          if (nodeId) {
-            saveValue(value, nodeId);
-          }
-
           config.onChange?.(value);
         },
       },
-      '' // Empty nodeId since we handle storage ourselves
+      ''
     );
 
     return div({ style: INLINE_COMPONENT_STYLE || '' }, knobContainer);

--- a/apps/play/src/audio-elements/elements/Sampler/component-utils.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/component-utils.ts
@@ -4,10 +4,7 @@ import van, { State } from '@repo/vanjs-core';
 import { ElementProps } from '@repo/vanjs-core/element';
 import { createKnob, KnobConfig } from '@/elements/primitives/createKnob';
 import { INLINE_COMPONENT_STYLE } from '../../shared/styles/component-styles';
-
-export const getSamplePlayerInstance = (): SamplePlayer | null => {
-  return (window as any).__samplePlayerInstance || null;
-};
+import { getSamplePlayer } from '../../../App';
 
 const { div } = van.tags;
 
@@ -22,7 +19,7 @@ export const createSamplerConnection = (
 
   const connect = () => {
     if (connected) return;
-    const sampler = getSamplePlayerInstance();
+    const sampler = getSamplePlayer();
     if (sampler) {
       connected = true;
       onConnect(sampler);
@@ -87,7 +84,7 @@ export const createToggleForTarget = (
 
     const connect = () => {
       if (connected) return;
-      const sampler = getSamplePlayerInstance();
+      const sampler = getSamplePlayer();
       if (sampler) {
         connected = true;
         config.onSamplerConnect?.(sampler, toggleState, van);
@@ -152,7 +149,7 @@ export const createKnobForTarget = (
 
     const connect = () => {
       if (connected) return;
-      const target = getSamplePlayerInstance();
+      const target = getSamplePlayer();
 
       if (target) {
         connected = true;

--- a/apps/play/src/audio-elements/elements/Sampler/components/ComputerKeyboard.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/ComputerKeyboard.ts
@@ -141,24 +141,17 @@ export const ComputerKeyboard = (attributes: ElementProps) => {
     }
   };
 
-  van.derive(updateKeyboardHandlers);
-
-  const checkInterval = setInterval(() => {
-    if (targetNodeId.val && !keyHandlersAttached && enabled.val) {
-      updateKeyboardHandlers();
-    }
-  }, 500);
-
   attributes.mount(() => {
+    document.addEventListener('sampler-initialized', updateKeyboardHandlers);
     // Listen for keymap changes from the select component
     document.addEventListener(
       'keymap-changed',
       handleKeymapChange as EventListener
     );
 
-    setTimeout(updateKeyboardHandlers, 100);
+    updateKeyboardHandlers();
     return () => {
-      clearInterval(checkInterval);
+      document.removeEventListener('sampler-initialized', updateKeyboardHandlers);
       document.removeEventListener(
         'keymap-changed',
         handleKeymapChange as EventListener

--- a/apps/play/src/audio-elements/elements/Sampler/components/ComputerKeyboard.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/ComputerKeyboard.ts
@@ -10,7 +10,7 @@ import {
 import KeyMaps, {
   DEFAULT_KEYMAP_KEY,
 } from '@/shared/keyboard/keyboard-keymaps';
-import { getSamplePlayerInstance } from '../component-utils';
+import { getSamplePlayer } from '../../../../App';
 import {
   COMPONENT_STYLE,
   HELP_TEXT_STYLE,
@@ -61,7 +61,7 @@ export const ComputerKeyboard = (attributes: ElementProps) => {
       else handleOctaveChange(-1);
     }
 
-    const sampler = getSamplePlayerInstance();
+    const sampler = getSamplePlayer();
     if (!sampler || !enabled.val) return;
 
     if (e.code === 'Space') {
@@ -99,7 +99,7 @@ export const ComputerKeyboard = (attributes: ElementProps) => {
     if (activeElement?.tagName === 'INPUT' && activeElement.type === 'text')
       return;
 
-    const sampler = getSamplePlayerInstance();
+    const sampler = getSamplePlayer();
     if (!sampler || !enabled.val) return;
 
     if (e.code === 'CapsLock') {
@@ -124,7 +124,7 @@ export const ComputerKeyboard = (attributes: ElementProps) => {
   };
 
   const updateKeyboardHandlers = () => {
-    const sampler = getSamplePlayerInstance();
+    const sampler = getSamplePlayer();
 
     if (sampler && enabled.val && !keyHandlersAttached) {
       document.addEventListener('keydown', keyDown);
@@ -166,7 +166,7 @@ export const ComputerKeyboard = (attributes: ElementProps) => {
       if (keyHandlersAttached) {
         document.removeEventListener('keydown', keyDown);
         document.removeEventListener('keyup', keyUp);
-        const sampler = getSamplePlayerInstance();
+        const sampler = getSamplePlayer();
         if (sampler) disableComputerKeyboard(sampler.nodeId);
       }
     };

--- a/apps/play/src/audio-elements/elements/Sampler/components/ComputerKeyboard.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/ComputerKeyboard.ts
@@ -10,7 +10,7 @@ import {
 import KeyMaps, {
   DEFAULT_KEYMAP_KEY,
 } from '@/shared/keyboard/keyboard-keymaps';
-import { getSampler } from '../SamplerRegistry';
+import { getSamplePlayerInstance } from '../component-utils';
 import {
   COMPONENT_STYLE,
   HELP_TEXT_STYLE,
@@ -61,7 +61,7 @@ export const ComputerKeyboard = (attributes: ElementProps) => {
       else handleOctaveChange(-1);
     }
 
-    const sampler = getSampler(targetNodeId.val);
+    const sampler = getSamplePlayerInstance();
     if (!sampler || !enabled.val) return;
 
     if (e.code === 'Space') {
@@ -99,7 +99,7 @@ export const ComputerKeyboard = (attributes: ElementProps) => {
     if (activeElement?.tagName === 'INPUT' && activeElement.type === 'text')
       return;
 
-    const sampler = getSampler(targetNodeId.val);
+    const sampler = getSamplePlayerInstance();
     if (!sampler || !enabled.val) return;
 
     if (e.code === 'CapsLock') {
@@ -124,7 +124,7 @@ export const ComputerKeyboard = (attributes: ElementProps) => {
   };
 
   const updateKeyboardHandlers = () => {
-    const sampler = getSampler(targetNodeId.val);
+    const sampler = getSamplePlayerInstance();
 
     if (sampler && enabled.val && !keyHandlersAttached) {
       document.addEventListener('keydown', keyDown);
@@ -166,7 +166,7 @@ export const ComputerKeyboard = (attributes: ElementProps) => {
       if (keyHandlersAttached) {
         document.removeEventListener('keydown', keyDown);
         document.removeEventListener('keyup', keyUp);
-        const sampler = getSampler(targetNodeId.val);
+        const sampler = getSamplePlayerInstance();
         if (sampler) disableComputerKeyboard(sampler.nodeId);
       }
     };

--- a/apps/play/src/audio-elements/elements/Sampler/components/EnvelopeDisplay.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/EnvelopeDisplay.ts
@@ -3,7 +3,7 @@ import van from '@repo/vanjs-core';
 import { ElementProps } from '@repo/vanjs-core/element';
 import { EnvelopeSVG } from '@/elements/controls/envelope';
 import { EnvelopeType } from '@repo/audiolib';
-import { getSampler } from '../SamplerRegistry';
+import { getSamplePlayerInstance } from '../component-utils';
 import { COMPONENT_STYLE } from '@/shared/styles/component-styles';
 
 const { div } = van.tags;
@@ -30,7 +30,7 @@ export const EnvelopeDisplay = (attributes: ElementProps) => {
       return;
     }
 
-    const sampler = getSampler(targetNodeId.val);
+    const sampler = getSamplePlayerInstance();
     if (!sampler) {
       console.log('No sampler found for nodeId:', targetNodeId.val);
       return;
@@ -125,7 +125,7 @@ export const EnvelopeDisplay = (attributes: ElementProps) => {
 
 //   const connect = () => {
 //     if (connected) return;
-//     const sampler = getSampler(targetNodeId.val);
+//     const sampler = getSamplePlayerInstance();
 //     if (!sampler) {
 //       console.log('No sampler found for nodeId:', targetNodeId.val);
 //       return;

--- a/apps/play/src/audio-elements/elements/Sampler/components/EnvelopeDisplay.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/EnvelopeDisplay.ts
@@ -78,6 +78,16 @@ export const EnvelopeDisplay = (attributes: ElementProps) => {
       handleSampleLoaded as EventListener
     );
 
+    // Hydrate immediately: the readiness events are one-shot and won't
+    // fire again if the sampler (and its initial sample) were already
+    // ready before this component mounted.
+    const sampler = getSamplePlayer();
+    if (sampler) {
+      samplerInitialized.val = true;
+      if (sampler.audiobuffer) sampleLoaded.val = true;
+      tryCreateEnvelope();
+    }
+
     return () => {
       if (envelopeInstance) {
         envelopeInstance.cleanup();

--- a/apps/play/src/audio-elements/elements/Sampler/components/EnvelopeDisplay.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/EnvelopeDisplay.ts
@@ -9,7 +9,6 @@ import { COMPONENT_STYLE } from '@/shared/styles/component-styles';
 const { div } = van.tags;
 
 export const EnvelopeDisplay = (attributes: ElementProps) => {
-  const targetNodeId = attributes.attr('target-node-id', '');
   const envelopeType = attributes.attr('envelope-type', 'amp-env');
   const width = attributes.attr('width', '100%');
   const height = attributes.attr('height', '200px');
@@ -32,7 +31,7 @@ export const EnvelopeDisplay = (attributes: ElementProps) => {
 
     const sampler = getSamplePlayer();
     if (!sampler) {
-      console.log('No sampler found for nodeId:', targetNodeId.val);
+      console.log('No sampler found');
       return;
     }
 
@@ -60,20 +59,14 @@ export const EnvelopeDisplay = (attributes: ElementProps) => {
   };
 
   attributes.mount(() => {
-    const handleSamplerInitialized = (e: Event) => {
-      const customEvent = e as CustomEvent;
-      if (customEvent.detail.nodeId === targetNodeId.val) {
-        samplerInitialized.val = true; // Update state
-        tryCreateEnvelope();
-      }
+    const handleSamplerInitialized = () => {
+      samplerInitialized.val = true;
+      tryCreateEnvelope();
     };
 
-    const handleSampleLoaded = (e: Event) => {
-      const customEvent = e as CustomEvent;
-      if (customEvent.detail.nodeId === targetNodeId.val) {
-        sampleLoaded.val = true; // Update state
-        tryCreateEnvelope();
-      }
+    const handleSampleLoaded = () => {
+      sampleLoaded.val = true;
+      tryCreateEnvelope();
     };
 
     document.addEventListener(

--- a/apps/play/src/audio-elements/elements/Sampler/components/EnvelopeDisplay.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/EnvelopeDisplay.ts
@@ -3,7 +3,7 @@ import van from '@repo/vanjs-core';
 import { ElementProps } from '@repo/vanjs-core/element';
 import { EnvelopeSVG } from '@/elements/controls/envelope';
 import { EnvelopeType } from '@repo/audiolib';
-import { getSamplePlayerInstance } from '../component-utils';
+import { getSamplePlayer } from '../../../../App';
 import { COMPONENT_STYLE } from '@/shared/styles/component-styles';
 
 const { div } = van.tags;
@@ -30,7 +30,7 @@ export const EnvelopeDisplay = (attributes: ElementProps) => {
       return;
     }
 
-    const sampler = getSamplePlayerInstance();
+    const sampler = getSamplePlayer();
     if (!sampler) {
       console.log('No sampler found for nodeId:', targetNodeId.val);
       return;
@@ -125,7 +125,7 @@ export const EnvelopeDisplay = (attributes: ElementProps) => {
 
 //   const connect = () => {
 //     if (connected) return;
-//     const sampler = getSamplePlayerInstance();
+//     const sampler = getSamplePlayer();
 //     if (!sampler) {
 //       console.log('No sampler found for nodeId:', targetNodeId.val);
 //       return;

--- a/apps/play/src/audio-elements/elements/Sampler/components/EnvelopeSwitcher.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/EnvelopeSwitcher.ts
@@ -127,6 +127,16 @@ export const EnvelopeSwitcher = (attributes: ElementProps) => {
       handleRestoreEnvelopes as EventListener,
     );
 
+    // Hydrate immediately: the readiness events are one-shot and won't
+    // fire again if the sampler (and its initial sample) were already
+    // ready before this component mounted.
+    const sampler = getSamplePlayer();
+    if (sampler) {
+      samplerInitialized.val = true;
+      if (sampler.audiobuffer) sampleLoaded.val = true;
+      if (samplerInitialized.val && sampleLoaded.val) createEnvelopes();
+    }
+
     return () => {
       Object.values(envelopes).forEach((env) => {
         if (env) env.cleanup();

--- a/apps/play/src/audio-elements/elements/Sampler/components/EnvelopeSwitcher.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/EnvelopeSwitcher.ts
@@ -3,7 +3,7 @@ import van from '@repo/vanjs-core';
 import { ElementProps } from '@repo/vanjs-core/element';
 import { EnvelopeSVG, EnvelopeSettings } from '@/elements/controls/envelope';
 import { EnvelopeType } from '@repo/audiolib';
-import { getSamplePlayerInstance } from '../component-utils';
+import { getSamplePlayer } from '../../../../App';
 import { COMPONENT_STYLE } from '@/shared/styles/component-styles';
 
 const { div, button } = van.tags;
@@ -33,7 +33,7 @@ export const EnvelopeSwitcher = (attributes: ElementProps) => {
   const createEnvelopes = () => {
     if (!samplerInitialized.val || !sampleLoaded.val) return;
 
-    const sampler = getSamplePlayerInstance();
+    const sampler = getSamplePlayer();
     if (!sampler) return;
 
     (Object.keys(envelopes) as SupportedEnvelopeType[]).forEach((envType) => {

--- a/apps/play/src/audio-elements/elements/Sampler/components/EnvelopeSwitcher.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/EnvelopeSwitcher.ts
@@ -3,7 +3,7 @@ import van from '@repo/vanjs-core';
 import { ElementProps } from '@repo/vanjs-core/element';
 import { EnvelopeSVG, EnvelopeSettings } from '@/elements/controls/envelope';
 import { EnvelopeType } from '@repo/audiolib';
-import { getSampler } from '../SamplerRegistry';
+import { getSamplePlayerInstance } from '../component-utils';
 import { COMPONENT_STYLE } from '@/shared/styles/component-styles';
 
 const { div, button } = van.tags;
@@ -33,7 +33,7 @@ export const EnvelopeSwitcher = (attributes: ElementProps) => {
   const createEnvelopes = () => {
     if (!samplerInitialized.val || !sampleLoaded.val) return;
 
-    const sampler = getSampler(targetNodeId.val);
+    const sampler = getSamplePlayerInstance();
     if (!sampler) return;
 
     (Object.keys(envelopes) as SupportedEnvelopeType[]).forEach((envType) => {

--- a/apps/play/src/audio-elements/elements/Sampler/components/EnvelopeSwitcher.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/EnvelopeSwitcher.ts
@@ -12,7 +12,6 @@ const { div, button } = van.tags;
 type SupportedEnvelopeType = 'amp-env' | 'filter-env' | 'pitch-env';
 
 export const EnvelopeSwitcher = (attributes: ElementProps) => {
-  const targetNodeId = attributes.attr('target-node-id', '');
   const width = attributes.attr('width', '100%');
   const height = attributes.attr('height', '200px');
   const bgColor = attributes.attr('bg-color', '#1e1e1e');
@@ -89,36 +88,28 @@ export const EnvelopeSwitcher = (attributes: ElementProps) => {
   });
 
   attributes.mount(() => {
-    const handlesamplerInitialized = (e: Event) => {
-      const customEvent = e as CustomEvent;
-      if (customEvent.detail.nodeId === targetNodeId.val) {
-        samplerInitialized.val = true;
-        if (sampleLoaded.val) {
-          createEnvelopes();
-        }
+    const handlesamplerInitialized = () => {
+      samplerInitialized.val = true;
+      if (sampleLoaded.val) {
+        createEnvelopes();
       }
     };
 
     const handleSampleLoaded = (e: Event) => {
       const customEvent = e as CustomEvent;
-      if (customEvent.detail.nodeId === targetNodeId.val) {
-        sampleLoaded.val = true;
-        // Store envelope settings if provided in the event
-        if (customEvent.detail.envelopeSettings) {
-          savedEnvelopeSettings = customEvent.detail.envelopeSettings;
-        }
-        if (samplerInitialized.val) {
-          createEnvelopes();
-        }
+      sampleLoaded.val = true;
+      // Store envelope settings if provided in the event
+      if (customEvent.detail.envelopeSettings) {
+        savedEnvelopeSettings = customEvent.detail.envelopeSettings;
+      }
+      if (samplerInitialized.val) {
+        createEnvelopes();
       }
     };
 
     const handleRestoreEnvelopes = (e: Event) => {
       const customEvent = e as CustomEvent;
-      if (
-        customEvent.detail.nodeId === targetNodeId.val &&
-        customEvent.detail.envelopeSettings
-      ) {
+      if (customEvent.detail.envelopeSettings) {
         restoreEnvelopeSettings(customEvent.detail.envelopeSettings);
       }
     };

--- a/apps/play/src/audio-elements/elements/Sampler/components/PianoKeyboard.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/PianoKeyboard.ts
@@ -1,7 +1,7 @@
 import van, { State } from '@repo/vanjs-core';
 import { ElementProps } from '@repo/vanjs-core/element';
 import '../../controls/webaudio-controls/webaudio-keyboard';
-import { getSamplePlayerInstance } from '../component-utils';
+import { getSamplePlayer } from '../../../../App';
 import {
   COMPONENT_STYLE,
   DISABLED_STYLE,
@@ -86,7 +86,7 @@ export const PianoKeyboard = (attributes: ElementProps) => {
   // Handle mouse/touch events only
   const handlePianoClick = (event: any) => {
     if (!enabled.val) return;
-    const sampler = getSamplePlayerInstance();
+    const sampler = getSamplePlayer();
     if (!sampler) return;
 
     const [noteState, noteNumber] = event.note;

--- a/apps/play/src/audio-elements/elements/Sampler/components/PianoKeyboard.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/PianoKeyboard.ts
@@ -139,8 +139,7 @@ export const PianoKeyboard = (attributes: ElementProps) => {
 
     // Listen for computer keyboard events to sync visual feedback
     const handleKeyboardEvents = (e: KeyboardEvent) => {
-      // Early exit if component is disabled or targetNodeId is empty
-      if (!enabled.val || !targetNodeId.val) return;
+      if (!enabled.val) return;
       if (e.repeat) return;
 
       const midiNote = currentKeymap.val[e.code];

--- a/apps/play/src/audio-elements/elements/Sampler/components/PianoKeyboard.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/PianoKeyboard.ts
@@ -1,7 +1,7 @@
 import van, { State } from '@repo/vanjs-core';
 import { ElementProps } from '@repo/vanjs-core/element';
 import '../../controls/webaudio-controls/webaudio-keyboard';
-import { getSampler } from '../SamplerRegistry';
+import { getSamplePlayerInstance } from '../component-utils';
 import {
   COMPONENT_STYLE,
   DISABLED_STYLE,
@@ -86,7 +86,7 @@ export const PianoKeyboard = (attributes: ElementProps) => {
   // Handle mouse/touch events only
   const handlePianoClick = (event: any) => {
     if (!enabled.val) return;
-    const sampler = getSampler(targetNodeId.val);
+    const sampler = getSamplePlayerInstance();
     if (!sampler) return;
 
     const [noteState, noteNumber] = event.note;

--- a/apps/play/src/audio-elements/elements/Sampler/components/SamplerButtonFactory.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/SamplerButtonFactory.ts
@@ -2,8 +2,7 @@
 import van, { State } from '@repo/vanjs-core';
 import { ElementProps } from '@repo/vanjs-core/element';
 import { createAudioRecorder, type Recorder } from '@repo/audiolib';
-import { getSampler, onRegistryChange } from '../SamplerRegistry';
-import { findNodeId } from '../component-utils';
+import { getSamplePlayerInstance } from '../component-utils';
 import { COMPONENT_STYLE } from '../../../shared/styles/component-styles';
 import {
   createSVGButton,
@@ -15,19 +14,11 @@ const { div } = van.tags;
 // ===== UPLOAD BUTTON =====
 
 export const UploadButton = (attributes: ElementProps) => {
-  const targetNodeId: State<string> = attributes.attr('target-node-id', '');
   const showStatus = attributes.attr('show-status', 'false');
   const status = van.state('Ready');
 
-  const getId = findNodeId(attributes, targetNodeId);
-
   const loadSample = async () => {
-    const nodeId = getId();
-    if (!nodeId) {
-      status.val = 'Sampler not found';
-      return;
-    }
-    const sampler = getSampler(nodeId);
+    const sampler = getSamplePlayerInstance();
     if (!sampler) {
       status.val = 'Sampler not found';
       return;
@@ -58,7 +49,6 @@ export const UploadButton = (attributes: ElementProps) => {
     fileInput.click();
   };
 
-  // Create SVG upload button using new function API
   const uploadButton = createSVGButton('Upload Sample', 'upload', {
     size: 'md',
     onClick: loadSample,
@@ -86,7 +76,6 @@ export const SaveButton = () => {
 // ===== RECORD BUTTON =====
 
 export const RecordButton = (attributes: ElementProps) => {
-  const targetNodeId: State<string> = attributes.attr('target-node-id', '');
   const showStatus = attributes.attr('show-status', 'false');
   const status = van.state('Ready');
 
@@ -95,12 +84,10 @@ export const RecordButton = (attributes: ElementProps) => {
     van.state('Record');
   const samplerAvailable = van.state(false);
 
-  const getId = findNodeId(attributes, targetNodeId);
-
   let recordButton: SVGButton;
 
   const startRecording = async () => {
-    const sampler = getSampler(getId());
+    const sampler = getSamplePlayerInstance();
     if (!sampler || recordBtnState.val === 'Recording') return;
 
     const inputSource = sampler.getRecorderInputSource();
@@ -213,17 +200,17 @@ export const RecordButton = (attributes: ElementProps) => {
 
   attributes.mount(() => {
     const checkSampler = () =>
-      (samplerAvailable.val = !!getSampler(getId()));
+      (samplerAvailable.val = !!getSamplePlayerInstance());
 
-    const cleanupSamplerCheck = onRegistryChange(checkSampler);
-
+    checkSampler();
+    document.addEventListener('sampler-initialized', checkSampler);
     return () => {
       if (currentRecorder.val) {
         currentRecorder.val.dispose();
         currentRecorder.val = null;
         recordBtnState.val = 'Record';
       }
-      cleanupSamplerCheck();
+      document.removeEventListener('sampler-initialized', checkSampler);
     };
   });
 

--- a/apps/play/src/audio-elements/elements/Sampler/components/SamplerButtonFactory.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/SamplerButtonFactory.ts
@@ -202,15 +202,18 @@ export const RecordButton = (attributes: ElementProps) => {
     const checkSampler = () =>
       (samplerAvailable.val = !!getSamplePlayer());
 
-    checkSampler();
-    document.addEventListener('sampler-initialized', checkSampler);
+    // Only mark available after sampler-initialized fires, not immediately
+    const handleSamplerInitialized = () => {
+      checkSampler();
+    };
+    document.addEventListener('sampler-initialized', handleSamplerInitialized);
     return () => {
       if (currentRecorder.val) {
         currentRecorder.val.dispose();
         currentRecorder.val = null;
         recordBtnState.val = 'Record';
       }
-      document.removeEventListener('sampler-initialized', checkSampler);
+      document.removeEventListener('sampler-initialized', handleSamplerInitialized);
     };
   });
 

--- a/apps/play/src/audio-elements/elements/Sampler/components/SamplerButtonFactory.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/SamplerButtonFactory.ts
@@ -2,7 +2,7 @@
 import van, { State } from '@repo/vanjs-core';
 import { ElementProps } from '@repo/vanjs-core/element';
 import { createAudioRecorder, type Recorder } from '@repo/audiolib';
-import { getSamplePlayerInstance } from '../component-utils';
+import { getSamplePlayer } from '../../../../App';
 import { COMPONENT_STYLE } from '../../../shared/styles/component-styles';
 import {
   createSVGButton,
@@ -18,7 +18,7 @@ export const UploadButton = (attributes: ElementProps) => {
   const status = van.state('Ready');
 
   const loadSample = async () => {
-    const sampler = getSamplePlayerInstance();
+    const sampler = getSamplePlayer();
     if (!sampler) {
       status.val = 'Sampler not found';
       return;
@@ -87,7 +87,7 @@ export const RecordButton = (attributes: ElementProps) => {
   let recordButton: SVGButton;
 
   const startRecording = async () => {
-    const sampler = getSamplePlayerInstance();
+    const sampler = getSamplePlayer();
     if (!sampler || recordBtnState.val === 'Recording') return;
 
     const inputSource = sampler.getRecorderInputSource();
@@ -200,7 +200,7 @@ export const RecordButton = (attributes: ElementProps) => {
 
   attributes.mount(() => {
     const checkSampler = () =>
-      (samplerAvailable.val = !!getSamplePlayerInstance());
+      (samplerAvailable.val = !!getSamplePlayer());
 
     checkSampler();
     document.addEventListener('sampler-initialized', checkSampler);

--- a/apps/play/src/audio-elements/elements/Sampler/components/SamplerKnobFactory.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/SamplerKnobFactory.ts
@@ -1,7 +1,6 @@
 // KnobFactory.ts
 import van from '@repo/vanjs-core';
 import { ElementProps } from '@repo/vanjs-core/element';
-import { getSampler } from '../SamplerRegistry';
 import { createKnobForTarget } from '../component-utils';
 import { KnobConfig } from '../../primitives/createKnob';
 
@@ -503,99 +502,63 @@ const tempoKnobConfig: KnobConfig = {
 
 // ===== EXPORTED KNOB COMPONENTS =====
 
-export const VolumeKnob = createKnobForTarget(volumeConfig, getSampler);
+export const VolumeKnob = createKnobForTarget(volumeConfig);
 
-export const DryWetKnob = createKnobForTarget(dryWetConfig, getSampler);
+export const DryWetKnob = createKnobForTarget(dryWetConfig);
 
-export const FeedbackKnob = createKnobForTarget(feedbackConfig, getSampler);
+export const FeedbackKnob = createKnobForTarget(feedbackConfig);
 
-export const DistortionKnob = createKnobForTarget(distortionConfig, getSampler);
+export const DistortionKnob = createKnobForTarget(distortionConfig);
 
-export const DriveKnob = createKnobForTarget(driveConfig, getSampler);
+export const DriveKnob = createKnobForTarget(driveConfig);
 
-export const ClippingKnob = createKnobForTarget(clippingConfig, getSampler);
+export const ClippingKnob = createKnobForTarget(clippingConfig);
 
-export const GlideKnob = createKnobForTarget(glideConfig, getSampler);
+export const GlideKnob = createKnobForTarget(glideConfig);
 
-export const FeedbackPitchKnob = createKnobForTarget(
-  feedbackPitchConfig,
-  getSampler
-);
+export const FeedbackPitchKnob = createKnobForTarget(feedbackPitchConfig);
 
-export const FeedbackDecayKnob = createKnobForTarget(
-  feedbackDecayConfig,
-  getSampler
-);
+export const FeedbackDecayKnob = createKnobForTarget(feedbackDecayConfig);
 
-export const FeedbackLpfKnob = createKnobForTarget(
-  feedbackLpfConfig,
-  getSampler
-);
+export const FeedbackLpfKnob = createKnobForTarget(feedbackLpfConfig);
 
-export const GainLFORateKnob = createKnobForTarget(
-  gainLFORateConfig,
-  getSampler
-);
+export const GainLFORateKnob = createKnobForTarget(gainLFORateConfig);
 
-export const GainLFODepthKnob = createKnobForTarget(
-  gainLFODepthConfig,
-  getSampler
-);
+export const GainLFODepthKnob = createKnobForTarget(gainLFODepthConfig);
 
-export const PitchLFORateKnob = createKnobForTarget(
-  pitchLFORateConfig,
-  getSampler
-);
+export const PitchLFORateKnob = createKnobForTarget(pitchLFORateConfig);
 
-export const PitchLFODepthKnob = createKnobForTarget(
-  pitchLFODepthConfig,
-  getSampler
-);
+export const PitchLFODepthKnob = createKnobForTarget(pitchLFODepthConfig);
 
-export const ReverbSendKnob = createKnobForTarget(reverbSendConfig, getSampler);
+export const ReverbSendKnob = createKnobForTarget(reverbSendConfig);
 
-export const ReverbSizeKnob = createKnobForTarget(reverbSizeConfig, getSampler);
+export const ReverbSizeKnob = createKnobForTarget(reverbSizeConfig);
 
-export const DelaySendKnob = createKnobForTarget(delaySendConfig, getSampler);
+export const DelaySendKnob = createKnobForTarget(delaySendConfig);
 
-export const DelayTimeKnob = createKnobForTarget(delayTimeConfig, getSampler);
+export const DelayTimeKnob = createKnobForTarget(delayTimeConfig);
 
-export const DelayFeedbackKnob = createKnobForTarget(delayFBConfig, getSampler);
+export const DelayFeedbackKnob = createKnobForTarget(delayFBConfig);
 
-export const LoopDurationDriftKnob = createKnobForTarget(
-  loopDurationDriftConfig,
-  getSampler
-);
+export const LoopDurationDriftKnob = createKnobForTarget(loopDurationDriftConfig);
 
-export const KeytrackLoopKnob = createKnobForTarget(
-  keytrackLoopConfig,
-  getSampler
-);
+export const KeytrackLoopKnob = createKnobForTarget(keytrackLoopConfig);
 
-export const LowpassFilterKnob = createKnobForTarget(
-  lowpassFilterConfig,
-  getSampler
-);
+export const LowpassFilterKnob = createKnobForTarget(lowpassFilterConfig);
 
-export const HighpassFilterKnob = createKnobForTarget(
-  highpassFilterConfig,
-  getSampler
-);
+export const HighpassFilterKnob = createKnobForTarget(highpassFilterConfig);
 
-export const AMModKnob = createKnobForTarget(amplitudeModConfig, getSampler);
+export const AMModKnob = createKnobForTarget(amplitudeModConfig);
 
-export const LoopStartKnob = createKnobForTarget(loopStartConfig, getSampler);
+export const LoopStartKnob = createKnobForTarget(loopStartConfig);
 
-export const LoopDurationKnob = createKnobForTarget(
-  loopDurationConfig,
-  getSampler
-);
+export const LoopDurationKnob = createKnobForTarget(loopDurationConfig);
 
-export const TrimStartKnob = createKnobForTarget(trimStartConfig, getSampler);
+export const TrimStartKnob = createKnobForTarget(trimStartConfig);
 
-export const TrimEndKnob = createKnobForTarget(trimEndConfig, getSampler);
+export const TrimEndKnob = createKnobForTarget(trimEndConfig);
 
-export const TempoKnob = createKnobForTarget(tempoKnobConfig, getSampler);
+export const TempoKnob = createKnobForTarget(tempoKnobConfig);
 
 // // ===== SHARED KNOB STATE REGISTRY =====
 // const knobStates = new Map<string, any>();

--- a/apps/play/src/audio-elements/elements/Sampler/components/SamplerSelectFactory.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/SamplerSelectFactory.ts
@@ -1,11 +1,10 @@
 // SamplerSelectFactory.ts - Select components for sampler controls
 import van, { State } from '@repo/vanjs-core';
 import { ElementProps } from '@repo/vanjs-core/element';
-import { getSampler } from '../SamplerRegistry';
+import { getSamplePlayerInstance, createSamplerConnection } from '../component-utils';
 import KeyMaps, {
   DEFAULT_KEYMAP_KEY,
 } from '@/shared/keyboard/keyboard-keymaps';
-import { findNodeId, createSamplerConnection } from '../component-utils';
 import {
   COMPONENT_STYLE,
   SELECT_STYLE,
@@ -206,27 +205,21 @@ const inputSourceSelectConfig: SelectConfig<
 
 const createSamplerSelect = <T extends string = string>(
   config: SelectConfig<T>,
-  getSamplerFn: (nodeId: string) => any,
   van: any,
   componentStyle: string,
   autoResize = true,
 ) => {
   return (attributes: ElementProps) => {
-    const targetNodeId: State<string> = attributes.attr('target-node-id', '');
     const showLabel = attributes.attr('show-label', 'false');
     const labelPosition = attributes.attr('label-position', 'inline'); // 'inline' or 'below'
     const state = van.state(config.defaultValue);
 
-    const getId = findNodeId(attributes, targetNodeId);
-
     // Use standardized connection utility
     const { createMountHandler } = createSamplerConnection(
-      getId,
-      getSamplerFn,
       (sampler: SamplePlayer) => {
         if (config.onTargetConnect) {
           try {
-            config.onTargetConnect(sampler, state, van, getId());
+            config.onTargetConnect(sampler, state, van, sampler.nodeId);
           } catch (error) {
             console.error(
               `Failed to connect select "${config.label || 'unnamed'}":`,
@@ -237,7 +230,7 @@ const createSamplerSelect = <T extends string = string>(
       },
     );
 
-    attributes.mount(createMountHandler(attributes));
+    attributes.mount(createMountHandler());
 
     const handleChange = (e: Event) => {
       const target = e.target as HTMLSelectElement;
@@ -381,28 +374,24 @@ const createSamplerSelect = <T extends string = string>(
 
 export const KeymapSelect = createSamplerSelect(
   keymapSelectConfig,
-  getSampler,
   van,
   COMPONENT_STYLE,
 );
 
 export const WaveformSelect = createSamplerSelect(
   waveformSelectConfig,
-  getSampler,
   van,
   COMPONENT_STYLE,
 );
 
 export const InputSourceSelect = createSamplerSelect(
   inputSourceSelectConfig,
-  getSampler,
   van,
   COMPONENT_STYLE,
 );
 
 export const RootNoteSelect = createSamplerSelect(
   rootNoteSelectConfig,
-  getSampler,
   van,
   COMPONENT_STYLE,
 );

--- a/apps/play/src/audio-elements/elements/Sampler/components/SamplerSelectFactory.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/SamplerSelectFactory.ts
@@ -1,7 +1,8 @@
 // SamplerSelectFactory.ts - Select components for sampler controls
 import van, { State } from '@repo/vanjs-core';
 import { ElementProps } from '@repo/vanjs-core/element';
-import { getSamplePlayerInstance, createSamplerConnection } from '../component-utils';
+import { getSamplePlayer } from '../../../../App';
+import { createSamplerConnection } from '../component-utils';
 import KeyMaps, {
   DEFAULT_KEYMAP_KEY,
 } from '@/shared/keyboard/keyboard-keymaps';

--- a/apps/play/src/audio-elements/elements/Sampler/components/SamplerStatusElement.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/SamplerStatusElement.ts
@@ -1,39 +1,29 @@
 // SamplerStatusElement.ts
 import van, { State } from '@repo/vanjs-core';
 import { ElementProps } from '@repo/vanjs-core/element';
-import { getSampler } from '../SamplerRegistry';
-import { findNodeId, createSamplerConnection } from '../component-utils';
+import { getSamplePlayerInstance, createSamplerConnection } from '../component-utils';
 
 const { div } = van.tags;
 
 export const SamplerStatusElement = (attributes: ElementProps) => {
-  const nodeId: State<string> = attributes.attr('target-node-id', '');
   const status = van.state('No sampler found');
-  const getId = findNodeId(attributes, nodeId);
 
   // Use standardized connection utility for initial status
   const { createMountHandler } = createSamplerConnection(
-    getId,
-    getSampler,
     () => (status.val = 'Initialized')
   );
 
   attributes.mount(() => {
     status.val = 'Click to start';
-    const disposeConnection = createMountHandler(attributes)();
+    const disposeConnection = createMountHandler();
 
     // Additional listeners for sample-loaded and error events
-    const handleSampleLoaded = (event: Event) => {
-      const customEvent = event as CustomEvent;
-      if (customEvent.detail?.nodeId === getId()) {
-        status.val = 'Sample loaded';
-      }
+    const handleSampleLoaded = () => {
+      status.val = 'Sample loaded';
     };
     const handleSamplerError = (event: Event) => {
       const customEvent = event as CustomEvent;
-      if (customEvent.detail?.nodeId === getId()) {
-        status.val = `Error: ${customEvent.detail.error}`;
-      }
+      status.val = `Error: ${customEvent.detail.error}`;
     };
     document.addEventListener('sample-loaded', handleSampleLoaded);
     document.addEventListener('sampler-error', handleSamplerError);
@@ -46,7 +36,6 @@ export const SamplerStatusElement = (attributes: ElementProps) => {
 
   return div(
     {
-      'target-node-id': () => nodeId.val,
       role: 'status',
       'aria-live': 'polite',
       'aria-atomic': 'true',

--- a/apps/play/src/audio-elements/elements/Sampler/components/SamplerStatusElement.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/SamplerStatusElement.ts
@@ -1,7 +1,8 @@
 // SamplerStatusElement.ts
 import van, { State } from '@repo/vanjs-core';
 import { ElementProps } from '@repo/vanjs-core/element';
-import { getSamplePlayerInstance, createSamplerConnection } from '../component-utils';
+import { getSamplePlayer } from '../../../../App';
+import { createSamplerConnection } from '../component-utils';
 
 const { div } = van.tags;
 

--- a/apps/play/src/audio-elements/elements/Sampler/components/SamplerStatusElement.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/SamplerStatusElement.ts
@@ -16,7 +16,7 @@ export const SamplerStatusElement = (attributes: ElementProps) => {
 
   attributes.mount(() => {
     status.val = 'Click to start';
-    const disposeConnection = createMountHandler();
+    const disposeConnection = createMountHandler()();
 
     // Additional listeners for sample-loaded and error events
     const handleSampleLoaded = () => {

--- a/apps/play/src/audio-elements/elements/Sampler/components/SamplerToggleFactory.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/SamplerToggleFactory.ts
@@ -1,7 +1,7 @@
 // SamplerToggleFactory.ts - Toggle and control components
 import van, { State } from '@repo/vanjs-core';
 import { ElementProps } from '@repo/vanjs-core/element';
-import { getSamplePlayerInstance } from '../component-utils';
+import { getSamplePlayer } from '../../../../App';
 import { Toggle } from '../../primitives/VanToggle';
 import { INLINE_COMPONENT_STYLE } from '../../../shared/styles/component-styles';
 import { createToggleForTarget, ToggleConfig } from '../component-utils';
@@ -17,7 +17,7 @@ export const MidiToggle = (attributes: ElementProps) => {
     size: 'md',
     onClick: () => {
       // TODO: Finish refacoring to use centralized input handling package
-      // const sampler = getSamplePlayerInstance();
+      // const sampler = getSamplePlayer();
       // if (!sampler) return;
       // const currentState = toggleButton.getState();
       // if (currentState === 'midi_on') {
@@ -41,7 +41,7 @@ export const PlaybackDirectionToggle = (attributes: ElementProps) => {
     {
       size: 'md',
       onClick: () => {
-        const sampler = getSamplePlayerInstance();
+        const sampler = getSamplePlayer();
         if (!sampler) return;
 
         const currentState = toggleButton.getState();
@@ -64,7 +64,7 @@ export const LoopLockToggle = (attributes: ElementProps) => {
     {
       size: 'md',
       onClick: () => {
-        const sampler = getSamplePlayerInstance();
+        const sampler = getSamplePlayer();
         if (!sampler) return;
 
         const currentState = toggleButton.getState();
@@ -88,7 +88,7 @@ export const HoldLockToggle = (attributes: ElementProps) => {
     {
       size: 'md',
       onClick: () => {
-        const sampler = getSamplePlayerInstance();
+        const sampler = getSamplePlayer();
         if (!sampler) return;
 
         const currentState = toggleButton.getState();
@@ -112,7 +112,7 @@ export const PitchToggle = (attributes: ElementProps) => {
     {
       size: 'md',
       onClick: () => {
-        const sampler = getSamplePlayerInstance();
+        const sampler = getSamplePlayer();
         if (!sampler) return;
 
         const currentState = toggleButton.getState();

--- a/apps/play/src/audio-elements/elements/Sampler/components/SamplerToggleFactory.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/SamplerToggleFactory.ts
@@ -1,7 +1,7 @@
 // SamplerToggleFactory.ts - Toggle and control components
 import van, { State } from '@repo/vanjs-core';
 import { ElementProps } from '@repo/vanjs-core/element';
-import { getSampler } from '../SamplerRegistry';
+import { getSamplePlayerInstance } from '../component-utils';
 import { Toggle } from '../../primitives/VanToggle';
 import { INLINE_COMPONENT_STYLE } from '../../../shared/styles/component-styles';
 import { createToggleForTarget, ToggleConfig } from '../component-utils';
@@ -17,7 +17,7 @@ export const MidiToggle = (attributes: ElementProps) => {
     size: 'md',
     onClick: () => {
       // TODO: Finish refacoring to use centralized input handling package
-      // const sampler = getSampler(targetNodeId.val);
+      // const sampler = getSamplePlayerInstance();
       // if (!sampler) return;
       // const currentState = toggleButton.getState();
       // if (currentState === 'midi_on') {
@@ -41,7 +41,7 @@ export const PlaybackDirectionToggle = (attributes: ElementProps) => {
     {
       size: 'md',
       onClick: () => {
-        const sampler = getSampler(targetNodeId.val);
+        const sampler = getSamplePlayerInstance();
         if (!sampler) return;
 
         const currentState = toggleButton.getState();
@@ -64,7 +64,7 @@ export const LoopLockToggle = (attributes: ElementProps) => {
     {
       size: 'md',
       onClick: () => {
-        const sampler = getSampler(targetNodeId.val);
+        const sampler = getSamplePlayerInstance();
         if (!sampler) return;
 
         const currentState = toggleButton.getState();
@@ -88,7 +88,7 @@ export const HoldLockToggle = (attributes: ElementProps) => {
     {
       size: 'md',
       onClick: () => {
-        const sampler = getSampler(targetNodeId.val);
+        const sampler = getSamplePlayerInstance();
         if (!sampler) return;
 
         const currentState = toggleButton.getState();
@@ -112,7 +112,7 @@ export const PitchToggle = (attributes: ElementProps) => {
     {
       size: 'md',
       onClick: () => {
-        const sampler = getSampler(targetNodeId.val);
+        const sampler = getSamplePlayerInstance();
         if (!sampler) return;
 
         const currentState = toggleButton.getState();
@@ -185,7 +185,6 @@ const panDriftConfig: ToggleConfig = {
 
 export const FeedbackModeToggle = createToggleForTarget(
   feedbackModeConfig,
-  getSampler,
   Toggle,
   van,
   INLINE_COMPONENT_STYLE
@@ -193,7 +192,6 @@ export const FeedbackModeToggle = createToggleForTarget(
 
 export const GainLFOSyncNoteToggle = createToggleForTarget(
   gainLFOSyncConfig,
-  getSampler,
   Toggle,
   van,
   INLINE_COMPONENT_STYLE
@@ -201,7 +199,6 @@ export const GainLFOSyncNoteToggle = createToggleForTarget(
 
 export const PitchLFOSyncNoteToggle = createToggleForTarget(
   pitchLFOSyncConfig,
-  getSampler,
   Toggle,
   van,
   INLINE_COMPONENT_STYLE
@@ -209,7 +206,6 @@ export const PitchLFOSyncNoteToggle = createToggleForTarget(
 
 export const PanDriftToggle = createToggleForTarget(
   panDriftConfig,
-  getSampler,
   Toggle,
   van,
   INLINE_COMPONENT_STYLE

--- a/apps/play/src/utils/createSampler.ts
+++ b/apps/play/src/utils/createSampler.ts
@@ -57,7 +57,9 @@ function validateWavBuffer(buffer: ArrayBuffer): boolean {
   for (let i = 0; i < samplesToCheck; i++) {
     const sampleIndex = Math.floor((i * numSamples) / samplesToCheck);
     if (bitsPerSample === 16) {
-      sumAbs += Math.abs(view.getInt16(dataOffset + sampleIndex * sampleSize, true));
+      sumAbs += Math.abs(
+        view.getInt16(dataOffset + sampleIndex * sampleSize, true),
+      );
     } else if (bitsPerSample === 8) {
       sumAbs += Math.abs(
         view.getUint8(dataOffset + sampleIndex * sampleSize) - 128,
@@ -98,23 +100,42 @@ export async function createSampler(
     );
     const nodeId = options.nodeId || samplePlayer.nodeId;
 
-    samplePlayer.onMessage('sample:loaded', (msg: any) => {
-      const audiobuffer = samplePlayer.audiobuffer;
+    const dispatchSampleLoaded = (buffer: AudioBuffer, msg: any) => {
       document.dispatchEvent(
         new CustomEvent('sample-loaded', {
           detail: {
             nodeId,
-            buffer: audiobuffer,
+            buffer,
             durationSeconds: msg.durationSeconds,
           },
         }),
       );
-      if (audiobuffer?.length) {
-        localStorage.setItem(
-          STORAGE_KEY,
-          arrayBufferToBase64(audioBufferToWav(audiobuffer)),
-        );
+    };
+
+    const localStoreSample = (buffer: AudioBuffer) => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        arrayBufferToBase64(audioBufferToWav(buffer)),
+      );
+    };
+
+    // Currently initial sample loads in audiolib DURING createSamplePlayer's async init (to be reconsidered)
+    // Dispatch the initial load
+    if (samplePlayer.audiobuffer?.length) {
+      dispatchSampleLoaded(samplePlayer.audiobuffer, {
+        durationSeconds: samplePlayer.audiobuffer.duration,
+      });
+      localStoreSample(samplePlayer.audiobuffer);
+    }
+
+    samplePlayer.onMessage('sample:loaded', (msg: any) => {
+      const audiobuffer = samplePlayer.audiobuffer;
+      if (!audiobuffer?.length) {
+        console.error('sample:loaded fired without usable audiobuffer');
+        return;
       }
+      dispatchSampleLoaded(audiobuffer, msg);
+      localStoreSample(audiobuffer);
     });
 
     return {

--- a/apps/play/src/utils/createSampler.ts
+++ b/apps/play/src/utils/createSampler.ts
@@ -98,10 +98,6 @@ export async function createSampler(
     );
     const nodeId = options.nodeId || samplePlayer.nodeId;
 
-    document.dispatchEvent(
-      new CustomEvent('sampler-initialized', { detail: { nodeId } }),
-    );
-
     samplePlayer.onMessage('sample:loaded', (msg: any) => {
       const audiobuffer = samplePlayer.audiobuffer;
       document.dispatchEvent(

--- a/apps/play/src/utils/createSampler.ts
+++ b/apps/play/src/utils/createSampler.ts
@@ -1,12 +1,6 @@
 // Replaces audio-components' <sampler-element>: creates the SamplePlayer,
-// restores/persists the current sample via localStorage, registers it in the
-// app-local sampler registry and dispatches the same DOM events, so the
-// remaining web components (knobs, toggles, keyboards) keep working unchanged.
+// restores/persists the current sample via localStorage, and dispatches events.
 import { createSamplePlayer, type SamplePlayer } from '@repo/audiolib';
-import {
-  registerSampler,
-  unregisterSampler,
-} from '../audio-elements/elements/Sampler/SamplerRegistry';
 import { audioBufferToWav } from './audio/audioBufferToWav';
 
 const STORAGE_KEY = 'currentSample';
@@ -104,7 +98,9 @@ export async function createSampler(
     );
     const nodeId = options.nodeId || samplePlayer.nodeId;
 
-    registerSampler(nodeId, samplePlayer);
+    // ponytail: global player store, single reference point for all controls.
+    // controls that need the player can import { getSamplePlayerInstance } and call it.
+    (window as any).__samplePlayerInstance = samplePlayer;
     document.dispatchEvent(
       new CustomEvent('sampler-initialized', { detail: { nodeId } }),
     );
@@ -132,7 +128,9 @@ export async function createSampler(
       nodeId,
       samplePlayer,
       dispose: () => {
-        unregisterSampler(nodeId);
+        if ((window as any).__samplePlayerInstance === samplePlayer) {
+          delete (window as any).__samplePlayerInstance;
+        }
         samplePlayer.dispose();
       },
     };

--- a/apps/play/src/utils/createSampler.ts
+++ b/apps/play/src/utils/createSampler.ts
@@ -98,9 +98,6 @@ export async function createSampler(
     );
     const nodeId = options.nodeId || samplePlayer.nodeId;
 
-    // ponytail: global player store, single reference point for all controls.
-    // controls that need the player can import { getSamplePlayerInstance } and call it.
-    (window as any).__samplePlayerInstance = samplePlayer;
     document.dispatchEvent(
       new CustomEvent('sampler-initialized', { detail: { nodeId } }),
     );
@@ -128,9 +125,6 @@ export async function createSampler(
       nodeId,
       samplePlayer,
       dispose: () => {
-        if ((window as any).__samplePlayerInstance === samplePlayer) {
-          delete (window as any).__samplePlayerInstance;
-        }
         samplePlayer.dispose();
       },
     };

--- a/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
+++ b/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
@@ -508,7 +508,9 @@ export class SamplePlayer implements ILibInstrumentNode {
   ): Promise<AudioBuffer | null> {
     if (buffer instanceof ArrayBuffer) {
       const ctx = getAudioContext();
-      buffer = await ctx.decodeAudioData(buffer);
+      // decodeAudioData detaches its input; copy so callers can safely
+      // reuse/re-pass the same ArrayBuffer (e.g. re-selecting a cached sample).
+      buffer = await ctx.decodeAudioData(buffer.slice(0));
     }
 
     if (!isValidAudioBuffer(buffer)) {


### PR DESCRIPTION
## Summary

Eliminated the `SamplerRegistry` + `target-node-id` + polling handshake pattern. Vanilla controls now access the player directly via a single app-level `__samplePlayerInstance` global.

**What changed:**
- Removed global `Map<nodeId, SamplePlayer>` registry and registry change callbacks
- Removed `findNodeId()` DOM lookup (target-node-id attribute → parent → nearest)
- Removed 100ms polling intervals in connection handlers
- Simplified connection logic: wait for `sampler-initialized` event once, then use single getter
- Updated 8 component factories (buttons, toggles, knobs, selects, envelopes, keyboards)
- Result: 190 lines removed, cleaner control flow, no registry churn

**Preserved:**
- `sampler-initialized` event for readiness signaling (fired when player created)
- All existing vanilla control functionality

**Follow-up fixes (same PR):**
- Record button stayed disabled after mount: fixed by only checking sampler availability after `sampler-initialized` fires, instead of on an immediate synchronous check
- `sampler-initialized` was dispatched before `App.tsx` had actually stored the player reference (event fired synchronously inside `createSampler()`, ref assignment happened in a later microtask), so any control mounting in that window missed the event permanently. Moved the dispatch to `App.tsx`, right after the reference is set
- Consolidated the player reference: removed the duplicate plain `samplePlayerRef` variable (and a shadowed inner `getSamplePlayer`) in favor of a single module-scoped SolidJS signal. Reactive JSX reads `samplePlayer()`; vanilla/imperative consumers read `getSamplePlayer()`, an untracked call into the same signal
- Small audiolib fix, folded in since it's tiny: `SamplePlayer.loadSample()` passed the caller's `ArrayBuffer` straight into `decodeAudioData()`, which detaches it per spec. Re-selecting the same saved sample twice threw `DataCloneError`. Now copies the buffer before decoding
- `sampler-status` element never reached "Initialized": `createMountHandler()` returns the handler to invoke, but it was stored instead of called
- `App.tsx` cleanup disposed nothing: the registry removal deleted the `samplerRef` needed to call `.dispose()`. Re-added a handle so unmount actually disposes the sampler and clears the signal
- Removed dead `target-node-id` readiness gating in `ComputerKeyboard`/`PianoKeyboard`/`EnvelopeDisplay`/`EnvelopeSwitcher` — a registry-era leftover that only still worked because every consumer hardcodes the same id. Replaced with direct trust in `sampler-initialized`/`sample-loaded` (and swapped `ComputerKeyboard`'s interval-polling retry for an event listener)
- `EnvelopeDisplay`/`EnvelopeSwitcher` now hydrate `getSamplePlayer()`/`.audiobuffer` immediately on mount instead of relying solely on the one-shot readiness events, which are missed entirely if the sampler was already ready before the component mounted
- Found while fixing the above: `sample-loaded` never fired for the app's initial sample at all. `createSampler()` subscribes to `SamplePlayer`'s internal `sample:loaded` message after `createSamplePlayer()` resolves, but the initial buffer (default asset or restored from localStorage) loads and emits that message *during* `createSamplePlayer()`, inside `SamplePlayer.init()` — before the listener exists, and the message bus has no replay. Quick fix: dispatch `sample-loaded` directly right after `createSamplePlayer()` returns, using the already-available `audiobuffer`. Proper fix (reordering `SamplePlayer`'s init/load sequence) deferred to a follow-up

## Verification
- ✅ Types check (`npx tsc --noEmit`)
- ✅ Build succeeds (`npm run build`)
- Manual browser testing done by author (sample selection, record button, reload)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Simplified sampler wiring across keyboards, envelopes, status, selectors, toggles, buttons, and knobs to use one app-level sampler handle.
  * Improved readiness by relying on `sampler-initialized` without node-id/registry scoping.
  * Removed polling-based connection retries and streamlined connection/disposal behavior.
* **Changes**
  * Knob settings now update in-session only; local persistence was removed.
* **Bug Fixes**
  * Loading a sample from an `ArrayBuffer` now avoids input-reuse/decode side effects.
* **Documentation**
  * Updated the simplification checklist to reflect the new sampler handoff approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


