### PR TITLE
Separate recorder input state from SamplePlayer

### DIFF
--- a/apps/play/src/App.tsx
+++ b/apps/play/src/App.tsx
@@ -25,6 +25,11 @@ import {
   saveCurrentSample,
   loadDefaultSample,
 } from './utils/audio/currentSampleStorage';
+import {
+  recorderInputDeviceId,
+  recorderInputSource,
+  setRecorderInputDeviceId,
+} from './utils/recorderSettings';
 
 import { ThemeToggle } from './components/ThemeSwitcher';
 import SaveButton from './components/SaveButton';
@@ -55,17 +60,9 @@ const App: Component = () => {
     'samples',
   );
 
-  let inputSourceSelectRef: HTMLElement | undefined;
-  const [inputSource, setInputSource] = createSignal('audio-input');
   const inputDeviceSelectDisabled = createMemo(
-    () => inputSource() !== 'audio-input',
+    () => recorderInputSource() !== 'audio-input',
   );
-
-  const [selectedInputDeviceId, setSelectedInputDeviceId] = createSignal('');
-  const handleInputDeviceChange = (deviceId: string) => {
-    getSamplePlayer()?.setRecorderInputDeviceId(deviceId);
-    setSelectedInputDeviceId(deviceId);
-  };
 
   const { handleSampleSelect } = useSampleSelection(
     getSamplePlayer,
@@ -98,14 +95,6 @@ const App: Component = () => {
           },
         }),
       );
-
-      // Preserve a device chosen before the player was ready
-      const chosenDeviceId = selectedInputDeviceId();
-      if (chosenDeviceId) {
-        samplePlayer.setRecorderInputDeviceId(chosenDeviceId);
-      } else {
-        setSelectedInputDeviceId(samplePlayer.getRecorderInputDeviceId() || '');
-      }
     };
 
     void (async () => {
@@ -171,15 +160,6 @@ const App: Component = () => {
     addExpandCollapseListeners();
     addPreventScrollOnSpacebarListener();
     window.addEventListener('resize', updateLayout);
-
-    const inputSourceSelect = inputSourceSelectRef?.querySelector('select');
-    setInputSource(inputSourceSelect?.value ?? 'audio-input');
-    const handleInputSourceChange = (e: Event) =>
-      setInputSource((e.target as HTMLSelectElement).value);
-    inputSourceSelect?.addEventListener('change', handleInputSourceChange);
-    onCleanup(() =>
-      inputSourceSelect?.removeEventListener('change', handleInputSourceChange),
-    );
 
     enableSamplePlayerMidi({
       getSamplePlayer,
@@ -298,8 +278,8 @@ const App: Component = () => {
             <InputDeviceSelect
               class={`toolbar-btn input-device-select ${toolbarOpen() ? '__toolbar-open' : ''}`}
               disabled={inputDeviceSelectDisabled()}
-              value={selectedInputDeviceId()}
-              onChange={handleInputDeviceChange}
+              value={recorderInputDeviceId()}
+              onChange={setRecorderInputDeviceId}
             />
 
             <OutputDeviceSelect
@@ -379,15 +359,14 @@ const App: Component = () => {
                 />
                 <div class='input-source-selection-container'>
                   <input-select
-                    ref={inputSourceSelectRef}
                     target-node-id='test-sampler'
                     class='input-source-select'
                   />
                   <InputDeviceSelect
                     class='input-device-select'
                     disabled={inputDeviceSelectDisabled()}
-                    value={selectedInputDeviceId()}
-                    onChange={handleInputDeviceChange}
+                    value={recorderInputDeviceId()}
+                    onChange={setRecorderInputDeviceId}
                   />
                 </div>
               </div>

--- a/apps/play/src/audio-elements/elements/Sampler/components/SamplerButtonFactory.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/SamplerButtonFactory.ts
@@ -1,7 +1,11 @@
 // SamplerButtonFactory.ts -
 import van, { State } from '@repo/vanjs-core';
 import { ElementProps } from '@repo/vanjs-core/element';
-import { createAudioRecorder, type Recorder } from '@repo/audiolib';
+import {
+  createAudioRecorder,
+  type Recorder,
+  type RecorderInput,
+} from '@repo/audiolib';
 import { getSamplePlayer } from '../../../../App';
 import { COMPONENT_STYLE } from '../../../shared/styles/component-styles';
 import {
@@ -92,6 +96,12 @@ export const RecordButton = (attributes: ElementProps) => {
     if (!sampler || recordBtnState.val === 'Recording') return;
 
     const { inputSource, inputDeviceId } = getRecorderSettings();
+    const input: RecorderInput =
+      inputSource === 'resample'
+        ? { type: 'audio-node', node: sampler.output }
+        : inputSource === 'browser'
+          ? { type: 'display' }
+          : { type: 'microphone', deviceId: inputDeviceId || undefined };
 
     try {
       const recorderResult = await createAudioRecorder(sampler.context);
@@ -99,13 +109,6 @@ export const RecordButton = (attributes: ElementProps) => {
       if (!recorderResult) {
         status.val = 'Failed to create recorder';
         return;
-      }
-
-      recorderResult.setInputSource(inputSource ?? 'audio-input');
-      recorderResult.setInputDeviceId(inputDeviceId);
-
-      if (inputSource === 'resample') {
-        recorderResult.connectResampleInputSource(sampler);
       }
 
       currentRecorder.val = recorderResult;
@@ -133,6 +136,7 @@ export const RecordButton = (attributes: ElementProps) => {
       });
 
       await currentRecorder.val.start({
+        input,
         useThreshold: true,
         startThreshold: -30,
         autoStop: true,

--- a/apps/play/src/audio-elements/elements/Sampler/components/SamplerButtonFactory.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/SamplerButtonFactory.ts
@@ -8,6 +8,7 @@ import {
   createSVGButton,
   type SVGButton,
 } from '../../primitives/createSVGButton';
+import { getRecorderSettings } from '../../../../utils/recorderSettings';
 
 const { div } = van.tags;
 
@@ -90,7 +91,7 @@ export const RecordButton = (attributes: ElementProps) => {
     const sampler = getSamplePlayer();
     if (!sampler || recordBtnState.val === 'Recording') return;
 
-    const inputSource = sampler.getRecorderInputSource();
+    const { inputSource, inputDeviceId } = getRecorderSettings();
 
     try {
       const recorderResult = await createAudioRecorder(sampler.context);
@@ -101,7 +102,7 @@ export const RecordButton = (attributes: ElementProps) => {
       }
 
       recorderResult.setInputSource(inputSource ?? 'audio-input');
-      recorderResult.setInputDeviceId(sampler.getRecorderInputDeviceId());
+      recorderResult.setInputDeviceId(inputDeviceId);
 
       if (inputSource === 'resample') {
         recorderResult.connectResampleInputSource(sampler);

--- a/apps/play/src/audio-elements/elements/Sampler/components/SamplerSelectFactory.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/SamplerSelectFactory.ts
@@ -17,6 +17,7 @@ import {
   SupportedWaveform,
 } from '@repo/audiolib';
 import { createWaveformIcon } from '@/shared/utils/icons/createWaveformIcons';
+import { setRecorderInputSource } from '../../../../utils/recorderSettings';
 
 const { div, select, option, span, button, selectedcontent, img } = van.tags;
 
@@ -197,7 +198,7 @@ const inputSourceSelectConfig: SelectConfig<
     targetNodeId: string,
   ) => {
     van.derive(() => {
-      sampler.setRecorderInputSource(state.val);
+      setRecorderInputSource(state.val);
     });
   },
 };

--- a/apps/play/src/utils/instrumentState.ts
+++ b/apps/play/src/utils/instrumentState.ts
@@ -411,9 +411,6 @@ export function restoreInstrumentState(settings: InstrumentSettings): void {
                 // We'll let the select's change event handle this properly
                 // by not interfering with the natural flow
                 break;
-              case 'input-select':
-                sampler.setRecorderInputSource(value);
-                break;
             }
           }
         }

--- a/apps/play/src/utils/recorderSettings.ts
+++ b/apps/play/src/utils/recorderSettings.ts
@@ -1,0 +1,14 @@
+import { createSignal } from 'solid-js';
+
+export type RecorderInputSource = 'audio-input' | 'browser' | 'resample';
+
+export const [recorderInputSource, setRecorderInputSource] =
+  createSignal<RecorderInputSource>('audio-input');
+
+export const [recorderInputDeviceId, setRecorderInputDeviceId] =
+  createSignal('');
+
+export const getRecorderSettings = () => ({
+  inputSource: recorderInputSource(),
+  inputDeviceId: recorderInputDeviceId(),
+});

--- a/packages/audiolib/src/index.ts
+++ b/packages/audiolib/src/index.ts
@@ -7,7 +7,11 @@ export { SamplePlayer } from './nodes/instruments/Sample/SamplePlayer';
 export { Oscilloscope } from './nodes/drafts/OscilloScope';
 
 // =*=*=  Types =*=*= \\
-export type { Recorder } from './nodes/recorder';
+export type {
+  Recorder,
+  RecorderInput,
+  RecorderStartOptions,
+} from './nodes/recorder';
 export type { LibNode, LibAudioNode, SampleLoader } from './nodes';
 export type {
   CustomEnvelope,

--- a/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
+++ b/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
@@ -49,7 +49,6 @@ import {
   CustomLibWaveform,
   WaveformOptions,
 } from '@/utils/audiodata/generate/generateWaveform';
-import { InputSource } from '@/nodes/recorder/Recorder';
 import { createSampleVoicePool } from './createSampleVoicePool';
 
 export class SamplePlayer implements ILibInstrumentNode {
@@ -102,9 +101,6 @@ export class SamplePlayer implements ILibInstrumentNode {
 
   voicePool!: SampleVoicePool; // todo: fix use of '!'
   outBus!: InstrumentBus; // todo: fix use of '!'
-
-  #recordInputSource: InputSource = 'audio-input';
-  #recordInputDeviceId = '';
 
   // ? move to input controller ?
   #sustainedNotes = new Set<MidiValue>();
@@ -184,22 +180,6 @@ export class SamplePlayer implements ILibInstrumentNode {
     this.voicePool.connect(this.outBus.input);
     this.outBus.connect(this.#masterOut);
     this.#masterOut.connect(this.context.destination);
-  }
-
-  setRecorderInputSource(source: InputSource) {
-    this.#recordInputSource = source;
-  }
-
-  getRecorderInputSource() {
-    return this.#recordInputSource;
-  }
-
-  setRecorderInputDeviceId(deviceId: string) {
-    this.#recordInputDeviceId = deviceId === 'default' ? '' : deviceId;
-  }
-
-  getRecorderInputDeviceId() {
-    return this.#recordInputDeviceId;
   }
 
   // === MESSAGING ===

--- a/packages/audiolib/src/nodes/recorder/Recorder.ts
+++ b/packages/audiolib/src/nodes/recorder/Recorder.ts
@@ -29,7 +29,6 @@ import {
   PreProcessOptions,
   PreProcessResults,
 } from '@/nodes/preprocessor/Preprocessor';
-import { SamplePlayer } from '../instruments';
 
 export const AudioRecorderState = {
   IDLE: 'IDLE',
@@ -45,8 +44,6 @@ export const DEFAULT_MEDIA_REC_OPTIONS: MediaRecorderOptions = {
   mimeType: 'audio/webm',
 };
 
-export type InputSource = 'audio-input' | 'browser' | 'resample';
-
 export type RecorderOptions = {
   mediaRecorderOptions: MediaRecorderOptions;
   useThreshold: boolean;
@@ -56,6 +53,15 @@ export type RecorderOptions = {
   silenceTimeoutMs: number;
   preprocess: boolean;
   preprocessOptions: object;
+};
+
+export type RecorderInput =
+  | { type: 'microphone'; deviceId?: string }
+  | { type: 'display' }
+  | { type: 'audio-node'; node: AudioNode };
+
+export type RecorderStartOptions = Partial<RecorderOptions> & {
+  input?: RecorderInput;
 };
 
 export const DEFAULT_RECORDER_OPTIONS: RecorderOptions = {
@@ -86,11 +92,9 @@ export class Recorder implements LibNode {
   #animationFrame: number | null = null;
   #silenceStartTime: number | null = null;
   #config: RecorderOptions | null = null;
-  #inputSource: InputSource = 'audio-input';
-  #inputDeviceId = '';
 
   #audioDestination: MediaStreamAudioDestinationNode | null = null;
-  #connectedSamplePlayer: SamplePlayer | null = null;
+  #connectedInputNode: AudioNode | null = null;
 
   constructor(context: AudioContext) {
     this.nodeId = registerNode(this.nodeType, this);
@@ -105,21 +109,15 @@ export class Recorder implements LibNode {
     return this;
   }
 
-  async #createResampleStream(): Promise<MediaStream> {
-    if (!this.#connectedSamplePlayer) {
-      throw new Error('No SamplePlayer connected for resampling');
-    }
-
-    // Create a destination that converts audio to MediaStream
+  async #createAudioNodeStream(node: AudioNode): Promise<MediaStream> {
     this.#audioDestination = this.#context.createMediaStreamDestination();
-
-    // Connect the SamplePlayer's output to our destination
-    this.#connectedSamplePlayer.output.connect(this.#audioDestination);
+    this.#connectedInputNode = node;
+    node.connect(this.#audioDestination);
 
     return this.#audioDestination.stream;
   }
 
-  async start(options?: Partial<RecorderOptions>): Promise<this> {
+  async start(options: RecorderStartOptions = {}): Promise<this> {
     if (this.#context.state === 'suspended') {
       await this.#context.resume();
     }
@@ -130,26 +128,27 @@ export class Recorder implements LibNode {
       this.#stream = null;
     }
 
-    // ? Use a lower threshold for browser input unless overridden
-    let config = { ...DEFAULT_RECORDER_OPTIONS, ...options };
+    const { input = { type: 'microphone' }, ...recorderOptions } = options;
 
-    if (
-      this.#inputSource === 'browser' &&
-      options?.startThreshold === undefined
-    ) {
+    // ? Use a lower threshold for browser input unless overridden
+    const config = { ...DEFAULT_RECORDER_OPTIONS, ...recorderOptions };
+
+    if (input.type === 'display' && options.startThreshold === undefined) {
       config.startThreshold = -60;
     }
     this.#config = config;
     let streamResult;
 
-    if (this.#inputSource === 'resample') {
-      streamResult = await tryCatch(() => this.#createResampleStream());
+    if (input.type === 'audio-node') {
+      streamResult = await tryCatch(() =>
+        this.#createAudioNodeStream(input.node),
+      );
       assert(
         !streamResult.error,
-        `Failed to create resample stream: ${streamResult.error}`,
+        `Failed to create audio-node stream: ${streamResult.error}`,
         streamResult
       );
-    } else if (this.#config && this.#inputSource === 'browser') {
+    } else if (input.type === 'display') {
       streamResult = await tryCatch(async () => {
         if (this.#context.state === 'suspended') {
           await this.#context.resume();
@@ -164,7 +163,7 @@ export class Recorder implements LibNode {
       );
     } else {
       streamResult = await tryCatch(() =>
-        getMicrophone(undefined, this.#inputDeviceId)
+        getMicrophone(undefined, input.deviceId)
       );
       assert(
         !streamResult.error,
@@ -217,14 +216,6 @@ export class Recorder implements LibNode {
 
     this.#startRecordingImmediate();
     return true;
-  }
-
-  setInputSource(source: InputSource) {
-    this.#inputSource = source;
-  }
-
-  setInputDeviceId(deviceId: string) {
-    this.#inputDeviceId = deviceId === 'default' ? '' : deviceId;
   }
 
   #startArmedRecording(): void {
@@ -390,16 +381,11 @@ export class Recorder implements LibNode {
     // Clean up - a new stream and recorder is created for each recording
     if (this.#stream) {
       this.#stream.getTracks().forEach((track) => track.stop());
-      // If inputSource is 'browser', also stop sharing
-      if (this.#inputSource === 'browser') {
-        this.#stream.getTracks().forEach((track) => track.stop());
-      }
     }
     this.#stream = null;
     this.#recorder = null;
 
-    // Clean up resample connection if used
-    this.#cleanupResampleConnection();
+    this.#cleanupAudioNodeConnection();
 
     return buffer;
   }
@@ -448,17 +434,11 @@ export class Recorder implements LibNode {
     return this;
   }
 
-  // Method to connect a SamplePlayer for resampling
-  connectResampleInputSource(samplePlayer: SamplePlayer): this {
-    this.#connectedSamplePlayer = samplePlayer;
-    return this;
-  }
-
-  // In stop() and dispose() methods
-  #cleanupResampleConnection(): void {
-    if (this.#audioDestination && this.#connectedSamplePlayer) {
-      this.#connectedSamplePlayer.output.disconnect(this.#audioDestination);
+  #cleanupAudioNodeConnection(): void {
+    if (this.#audioDestination && this.#connectedInputNode) {
+      this.#connectedInputNode.disconnect(this.#audioDestination);
       this.#audioDestination = null;
+      this.#connectedInputNode = null;
     }
   }
 
@@ -468,7 +448,7 @@ export class Recorder implements LibNode {
 
   dispose(): void {
     this.#cleanupMonitoring();
-    this.#cleanupResampleConnection();
+    this.#cleanupAudioNodeConnection();
     this.#stream?.getTracks().forEach((track) => track.stop());
     this.#stream = null;
     this.#recorder = null;

--- a/packages/audiolib/src/nodes/recorder/Recorder.ts
+++ b/packages/audiolib/src/nodes/recorder/Recorder.ts
@@ -127,6 +127,7 @@ export class Recorder implements LibNode {
       this.#stream.getTracks().forEach((track) => track.stop());
       this.#stream = null;
     }
+    this.#cleanupAudioNodeConnection();
 
     const { input = { type: 'microphone' }, ...recorderOptions } = options;
 

--- a/packages/audiolib/src/nodes/recorder/index.ts
+++ b/packages/audiolib/src/nodes/recorder/index.ts
@@ -1,2 +1,2 @@
-// export * from './Recorder';
 export * from './factory';
+export type { RecorderInput, RecorderStartOptions } from './Recorder';


### PR DESCRIPTION
## What changed

- Move recorder source and device selections into Play-owned state.
- Remove recording-selection storage from `SamplePlayer`.
- Configure recorder input as part of `Recorder.start()`.
- Add typed microphone, display, and generic `AudioNode` inputs.
- Remove the `SamplePlayer`-specific resampling connection from `Recorder`.

## Commit structure

1. `ec6eefd` contains only the minimal state-ownership change while retaining the existing Recorder setter API.
2. `e8ac8e6` contains the additional Recorder API improvements for independent review.

## Why

Recording selections describe a recording operation, not sample playback. Play now owns the user's selection while audiolib owns the typed recording behavior, without requiring Recorder to depend on SamplePlayer.

## Validation

- `pnpm --filter @repo/audiolib test` — 116 passed, 1 skipped
- `pnpm --filter @repo/audiolib build`
- `pnpm --filter play build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unified recorder input settings so source (microphone, display/system, or sampler audio) and input device choices are shared across the recorder UI.
  * Recording now accepts a typed recorder input (including audio routed from the sampler).

* **Improvements**
  * Input-source and input-device selections stay synchronized between toolbar and sampler views.
  * Recorder startup and cleanup were reworked for more consistent stream handling and routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->