### PR TITLE
Preserve sample duration during pitched playback

### DIFF
--- a/apps/play/src/App.tsx
+++ b/apps/play/src/App.tsx
@@ -663,7 +663,12 @@ const App: Component = () => {
           <fieldset class='control-group toggle-group'>
             <legend class='expandable-legend'>Toggles</legend>
             <div class='expandable-content'>
-              <midi-toggle target-node-id='test-sampler' />
+              <SamplerToggle
+                param='timestretch'
+                player={samplePlayer()}
+                class='sampler-toggle-container'
+              />
+              {/* <midi-toggle target-node-id='test-sampler' /> */}
               <playback-direction-toggle target-node-id='test-sampler' />
               <loop-lock-toggle target-node-id='test-sampler' />
               <hold-lock-toggle target-node-id='test-sampler' />

--- a/apps/play/src/audio-elements/elements/Sampler/Sampler.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/Sampler.ts
@@ -25,25 +25,6 @@ import {
 } from './components/SamplerSelectFactory';
 import { SamplerStatusElement } from './components/SamplerStatusElement';
 
-export {
-  MidiToggle,
-  LoopLockToggle,
-  HoldLockToggle,
-  PlaybackDirectionToggle,
-  PitchToggle,
-  ComputerKeyboard,
-  PianoKeyboard,
-  RecordButton,
-  UploadButton,
-  SaveButton,
-  KeymapSelect,
-  WaveformSelect,
-  InputSourceSelect,
-  RootNoteSelect,
-  SamplerStatusElement,
-  EnvelopeDisplay,
-};
-
 const defineIfNotExists = (name: string, elementFunc: any, options: any) => {
   if (!customElements.get(name)) {
     define(name, elementFunc, options);
@@ -78,4 +59,23 @@ export const defineSampler = () => {
   defineIfNotExists('rootnote-select', RootNoteSelect, false);
 
   defineIfNotExists('sampler-status', SamplerStatusElement, false);
+};
+
+export {
+  MidiToggle,
+  LoopLockToggle,
+  HoldLockToggle,
+  PlaybackDirectionToggle,
+  PitchToggle,
+  ComputerKeyboard,
+  PianoKeyboard,
+  RecordButton,
+  UploadButton,
+  SaveButton,
+  KeymapSelect,
+  WaveformSelect,
+  InputSourceSelect,
+  RootNoteSelect,
+  SamplerStatusElement,
+  EnvelopeDisplay,
 };

--- a/apps/play/src/audio-elements/elements/Sampler/components/SamplerToggleFactory.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/SamplerToggleFactory.ts
@@ -40,7 +40,7 @@ export const PlaybackDirectionToggle = () => {
           currentState === 'direction_reverse' ? 'reverse' : 'forward';
         sampler.setPlaybackDirection(direction);
       },
-    }
+    },
   );
 
   return div({ style: '' }, toggleButton);
@@ -62,7 +62,7 @@ export const LoopLockToggle = () => {
         sampler.setLoopLocked(shouldLock);
       },
       initialState: 'loop_unlocked',
-    }
+    },
   );
 
   return div({ style: '' }, toggleButton);
@@ -84,7 +84,7 @@ export const HoldLockToggle = () => {
         sampler.setHoldLocked(shouldLock);
       },
       initialState: 'hold_unlocked',
-    }
+    },
   );
 
   return div({ style: '' }, toggleButton);
@@ -105,7 +105,7 @@ export const PitchToggle = () => {
         if (currentState === 'pitch_on') sampler.enablePitch();
         else if (currentState === 'pitch_off') sampler.disablePitch();
       },
-    }
+    },
   );
 
   return div({ style: '' }, toggleButton);

--- a/apps/play/src/components/SamplerToggle.tsx
+++ b/apps/play/src/components/SamplerToggle.tsx
@@ -9,6 +9,7 @@ import styles from './SamplerToggle.module.css';
 interface SamplerToggleProps {
   param: SamplerToggleKey;
   player: SamplePlayer | null;
+  class?: string;
 }
 
 const SamplerToggle: Component<SamplerToggleProps> = (props) => {
@@ -21,23 +22,25 @@ const SamplerToggle: Component<SamplerToggleProps> = (props) => {
   });
 
   return (
-    <label
-      class={`${styles.toggle} ${enabled() ? styles.enabled : ''} ${props.player ? '' : styles.disabled}`}
-      title={descriptor.label}
-    >
-      <input
-        class={styles.input}
-        type='checkbox'
-        aria-label={descriptor.label}
-        checked={enabled()}
-        disabled={!props.player}
-        onInput={(event) => setEnabled(event.currentTarget.checked)}
-      />
-      <span class={styles.container} aria-hidden='true'>
-        <span class={styles.switch} />
-      </span>
-      <span class={styles.label}>{descriptor.format(enabled())}</span>
-    </label>
+    <div class={props.class || ''}>
+      <label
+        class={`${styles.toggle} ${enabled() ? styles.enabled : ''} ${props.player ? '' : styles.disabled}`}
+        title={descriptor.label}
+      >
+        <input
+          class={styles.input}
+          type='checkbox'
+          aria-label={descriptor.label}
+          checked={enabled()}
+          disabled={!props.player}
+          onInput={(event) => setEnabled(event.currentTarget.checked)}
+        />
+        <span class={styles.container} aria-hidden='true'>
+          <span class={styles.switch} />
+        </span>
+        <span class={styles.label}>{descriptor.format(enabled())}</span>
+      </label>
+    </div>
   );
 };
 

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -426,6 +426,14 @@ option:checked {
   gap: 0.2rem;
 }
 
+.toggle-group .sampler-toggle-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+}
+
 .toggle-group sampler-status {
   display: flex;
   align-items: center;

--- a/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
+++ b/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
@@ -839,6 +839,15 @@ export class SamplePlayer implements ILibInstrumentNode {
     return this;
   };
 
+  setTimestretchEnabled = (enabled: boolean) => {
+    this.voicePool.applyToAllVoices((voice) =>
+      voice.setTimestretchEnabled(enabled),
+    );
+
+    this.storeParamValue('timestretchEnabled', enabled);
+    return this;
+  };
+
   isNormalized = (value: number, range = [0, 1]) =>
     value >= range[0] && value <= range[1];
 
@@ -891,7 +900,7 @@ export class SamplePlayer implements ILibInstrumentNode {
     const clamped = Math.max(0, Math.min(1, amount));
     this.#keytrackLoopAmount = clamped;
     this.voicePool.applyToAllVoices((voice) =>
-      voice.setKeytrackLoopAmount(clamped)
+      voice.setKeytrackLoopAmount(clamped),
     );
     this.storeParamValue('keytrackLoopAmount', clamped);
     return this;
@@ -903,7 +912,7 @@ export class SamplePlayer implements ILibInstrumentNode {
   getKeytrackLoopAmount = () => {
     this.#keytrackLoopAmount ??= this.getStoredParamValue(
       'keytrackLoopAmount',
-      0
+      0,
     );
     return this.#keytrackLoopAmount;
   };

--- a/packages/audiolib/src/nodes/instruments/Sample/SampleVoice.ts
+++ b/packages/audiolib/src/nodes/instruments/Sample/SampleVoice.ts
@@ -77,7 +77,7 @@ export class SampleVoice {
 
   constructor(
     private context: AudioContext = getAudioContext(),
-    options: { processorOptions?: any; enableFilters?: boolean } = {}
+    options: { processorOptions?: any; enableFilters?: boolean } = {},
   ) {
     this.nodeId = registerNode(this.nodeType, this);
     this.#messages = createMessageBus<Message>(this.nodeId);
@@ -93,7 +93,7 @@ export class SampleVoice {
         numberOfOutputs: 1,
         outputChannelCount: [2], // Force stereo output
         processorOptions: options.processorOptions || {},
-      }
+      },
     );
 
     // Connections are made in #connectAudioChain() during init()
@@ -213,25 +213,25 @@ export class SampleVoice {
   #logAvailableParams = () => {
     console.table(
       'Available worklet params:',
-      Array.from(this.#playerWorklet.parameters.keys())
+      Array.from(this.#playerWorklet.parameters.keys()),
     );
   };
 
   async loadBuffer(
     buffer: AudioBuffer,
-    zeroCrossings?: number[]
+    zeroCrossings?: number[],
   ): Promise<boolean> {
     this.#state = VoiceState.NOT_READY;
 
     if (buffer.sampleRate !== this.context.sampleRate) {
       console.warn(
-        `Sample rate mismatch - buffer: ${buffer.sampleRate}, context: ${this.context.sampleRate}`
+        `Sample rate mismatch - buffer: ${buffer.sampleRate}, context: ${this.context.sampleRate}`,
       );
       return false;
     }
 
     const bufferData = Array.from({ length: buffer.numberOfChannels }, (_, i) =>
-      buffer.getChannelData(i).slice()
+      buffer.getChannelData(i).slice(),
     );
 
     this.sendToProcessor({
@@ -255,7 +255,7 @@ export class SampleVoice {
   freeze(freeze: boolean): this {
     console.info(
       `SampleVoice: freeze(${freeze}) called. 
-      Spectral freeze not implemented yet`
+      Spectral freeze not implemented yet`,
     );
     // if (this.#isFrozen === freeze) return this; // idempotent
     // this.#isFrozen = freeze;
@@ -336,7 +336,7 @@ export class SampleVoice {
       this.getParam('playbackRate')!.setTargetAtTime(
         playbackRate,
         timestamp,
-        scaledGlideTime
+        scaledGlideTime,
       );
     } else {
       this.setParam('playbackRate', playbackRate, timestamp);
@@ -375,7 +375,7 @@ export class SampleVoice {
     timestamp: number,
     playbackRate: number,
     velocity?: number,
-    midiNote?: number
+    midiNote?: number,
   ) {
     this.#envelopes.forEach((env, envType) => {
       if (!env.isEnabled) return;
@@ -463,13 +463,13 @@ export class SampleVoice {
 
     // Get longest release time of enabled envelopes
     const enabledEnvelopes = Array.from(this.#envelopes.values()).filter(
-      (env) => env.isEnabled
+      (env) => env.isEnabled,
     );
 
     const effectiveReleaseTime =
       enabledEnvelopes.length > 0
         ? Math.max(
-            ...enabledEnvelopes.map((env) => env.effectiveReleaseDuration)
+            ...enabledEnvelopes.map((env) => env.effectiveReleaseDuration),
           )
         : releaseTime; // Fallback passed in release time
 
@@ -488,7 +488,7 @@ export class SampleVoice {
           this.#releaseTimeout = null;
         }
       },
-      effectiveReleaseTime * 1000 + 50
+      effectiveReleaseTime * 1000 + 50,
     ); // 50ms buffer
 
     return this;
@@ -517,7 +517,7 @@ export class SampleVoice {
         this.sendToProcessor({ type: 'voice:stop', timestamp: stopAt });
         this.#stopTimeout = null;
       },
-      Math.max(0, (stopAt + deClickSeconds - this.now) * 1000)
+      Math.max(0, (stopAt + deClickSeconds - this.now) * 1000),
     );
     return this;
   }
@@ -529,7 +529,7 @@ export class SampleVoice {
     options: {
       glideTime?: number;
       cancelPrevious?: boolean;
-    } = {}
+    } = {},
   ) {
     if (!this.#activeMidiNote || !this.#hpf || this.#keytrackHPFAmount <= 0) {
       return;
@@ -559,7 +559,7 @@ export class SampleVoice {
     options: {
       glideTime?: number;
       cancelPrevious?: boolean;
-    } = {}
+    } = {},
   ) {
     if (!this.#activeMidiNote || !this.#lpf || this.#keytrackLPFAmount <= 0) {
       return;
@@ -588,7 +588,7 @@ export class SampleVoice {
   #setupAmpModLFO(
     depth = 0,
     waveform: CustomLibWaveform | OscillatorType | PeriodicWave = 'square',
-    customWaveOptions: WaveformOptions = {}
+    customWaveOptions: WaveformOptions = {},
   ) {
     if (this.#am_lfo === null) {
       this.#am_lfo = new LFO(this.context);
@@ -634,7 +634,7 @@ export class SampleVoice {
   setModulationWaveform(
     modType: 'AM' | 'FM' = 'AM',
     waveform: CustomLibWaveform | OscillatorType | PeriodicWave = 'triangle',
-    customWaveOptions: WaveformOptions = {}
+    customWaveOptions: WaveformOptions = {},
   ) {
     if (modType === 'AM') {
       if (!this.#am_lfo) this.#setupAmpModLFO();
@@ -685,7 +685,7 @@ export class SampleVoice {
     envType: EnvelopeType,
     index: number,
     time?: number,
-    value?: number
+    value?: number,
   ) {
     const env = this.#envelopes.get(envType);
     if (env?.isEnabled) env.updatePoint(index, time, value);
@@ -719,7 +719,7 @@ export class SampleVoice {
     options: {
       glideTime?: number;
       cancelPrevious?: boolean;
-    } = {}
+    } = {},
   ): this {
     const param = this.getParam(name);
     if (!param || param.value === targetValue) return this;
@@ -733,7 +733,7 @@ export class SampleVoice {
     else
       param.linearRampToValueAtTime(
         targetValue,
-        timestamp + Math.max(glideTime, 0.001)
+        timestamp + Math.max(glideTime, 0.001),
       );
 
     return this;
@@ -745,10 +745,10 @@ export class SampleVoice {
     options: {
       glideTime?: number;
       cancelPrevious?: boolean;
-    } = {}
+    } = {},
   ): this {
     const validParams = paramsAndValues.filter(
-      (pv) => this.getParam(pv.name) !== null
+      (pv) => this.getParam(pv.name) !== null,
     );
     if (validParams.length === 0) return this;
 
@@ -763,7 +763,7 @@ export class SampleVoice {
     start: number,
     end: number,
     timestamp = this.now,
-    rampTime = 0
+    rampTime = 0,
   ): this {
     if (start >= end) return this;
 
@@ -820,7 +820,7 @@ export class SampleVoice {
 
     this.getParam('playbackRate')?.linearRampToValueAtTime(
       1,
-      timestamp + glideTime
+      timestamp + glideTime,
     );
 
     this.#updateHPFCutoffForPlaybackRate(1, timestamp, { glideTime });
@@ -836,7 +836,7 @@ export class SampleVoice {
       const rate = midiToPlaybackRate(this.#activeMidiNote);
       this.getParam('playbackRate')?.linearRampToValueAtTime(
         rate,
-        this.context.currentTime + 0.01
+        this.context.currentTime + 0.01,
       );
       this.#updateHPFCutoffForPlaybackRate(rate, timestamp, {
         glideTime,
@@ -852,7 +852,7 @@ export class SampleVoice {
   connect(
     destination: Destination,
     output?: number,
-    input?: number
+    input?: number,
   ): Destination {
     if (destination instanceof LibAudioNode) {
       this.out.connect(destination.input, output);
@@ -911,7 +911,7 @@ export class SampleVoice {
           ...msg,
           voiceId: this.nodeId,
           midiNote: this.#activeMidiNote,
-        })
+        }),
       );
     });
   }
@@ -984,7 +984,7 @@ export class SampleVoice {
         case 'voice:position':
           this.getParam('playbackPosition')?.setValueAtTime(
             data.position,
-            this.context.currentTime
+            this.context.currentTime,
           );
           break;
 
@@ -994,7 +994,7 @@ export class SampleVoice {
             { loopStart: data.loopStart },
             { loopStartSamples: data.loopStartSamples },
             { loopEnd: data.loopEnd },
-            { loopEndSamples: data.loopEndSamples }
+            { loopEndSamples: data.loopEndSamples },
           );
           break;
 
@@ -1117,7 +1117,7 @@ export class SampleVoice {
   setEnvelopeLoop = (
     envType: EnvelopeType,
     loop: boolean,
-    mode: 'normal' | 'ping-pong' | 'reverse' = 'normal'
+    mode: 'normal' | 'ping-pong' | 'reverse' = 'normal',
   ) => {
     const env = this.#envelopes.get(envType);
     env?.setLoopEnabled(loop, mode);
@@ -1136,7 +1136,7 @@ export class SampleVoice {
     options?: {
       glideTime?: number;
       cancelPrevious?: boolean;
-    }
+    },
   ): this {
     this.setParam('playbackRate', rate, atTime, options);
     this.#updateHPFCutoffForPlaybackRate(rate, atTime, options);
@@ -1147,7 +1147,7 @@ export class SampleVoice {
   setHpfCutoff(
     hz: number,
     atTime: number = this.now,
-    options: { glideTime?: number; cancelPrevious?: boolean } = {}
+    options: { glideTime?: number; cancelPrevious?: boolean } = {},
   ) {
     const safeHz = clamp(hz, 20, this.context.sampleRate / 2 - 1000);
     this.#hpfHz = safeHz;
@@ -1163,7 +1163,7 @@ export class SampleVoice {
   setLpfCutoff(
     hz: number,
     atTime: number = this.now,
-    options: { glideTime?: number; cancelPrevious?: boolean } = {}
+    options: { glideTime?: number; cancelPrevious?: boolean } = {},
   ) {
     const safeHz = clamp(hz, 20, this.context.sampleRate / 2 - 1000);
     this.#lpfHz = safeHz;
@@ -1212,6 +1212,9 @@ export class SampleVoice {
 
   setPanDriftEnabled = (enabled: boolean) =>
     this.sendToProcessor({ type: 'setPanDriftEnabled', value: enabled });
+
+  setTimestretchEnabled = (enabled: boolean) =>
+    this.sendToProcessor({ type: 'setPreserveDuration', value: enabled });
 
   debugDuration() {
     console.info(`

--- a/packages/audiolib/src/nodes/instruments/Sample/sampler-toggles.ts
+++ b/packages/audiolib/src/nodes/instruments/Sample/sampler-toggles.ts
@@ -8,6 +8,12 @@ export interface SamplerToggleDescriptor {
 }
 
 export const samplerToggles = {
+  timestretch: {
+    label: 'Timestretch',
+    defaultValue: false,
+    format: (enabled) => (enabled ? 'Warp' : 'RePitch'),
+    apply: (player, enabled) => player.setTimestretchEnabled(enabled),
+  },
   panDrift: {
     label: 'Pan drift',
     defaultValue: true,

--- a/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
+++ b/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
@@ -119,6 +119,15 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
     // NOTE: Using keytrackLoopAmount > 0 means that audio-rate loop lengths no longer quantize to midinote
     this.keytrackLoopAmount = 0;
 
+    // Experimental duration preservation. Kept as one feature state object so
+    // it can be extracted from this processor cleanly later.
+    this.durationPreservation = {
+      enabled: true,
+      maxDriftSamples: Math.floor(sampleRate * 0.04),
+      timelinePosition: 0,
+      resetPending: false,
+    };
+
     // C0 (lowest piano note) = ~16.35 Hz
     // Period = 1/16.35 ≈ 0.061 seconds
     this.PITCH_PRESERVATION_THRESHOLD = Math.floor(sampleRate * 0.061);
@@ -263,6 +272,11 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
       case 'setKeytrackLoopAmount':
         this.keytrackLoopAmount = Math.max(0, Math.min(1, value));
         break;
+
+      case 'setPreserveDuration':
+        this.durationPreservation.enabled = Boolean(value);
+        this.#resetDurationPreservation(this.playbackPosition);
+        break;
     }
   }
 
@@ -295,6 +309,8 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
     this.loopAmplitudeGain = 1.0;
     this.lastAnalyzedLoopStart = -1;
     this.lastAnalyzedLoopEnd = -1;
+
+    this.#resetDurationPreservation();
   }
 
   #stop() {
@@ -649,6 +665,66 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
     return this.constantFlags;
   }
 
+  // ===== DURATION PRESERVATION =====
+
+  #resetDurationPreservation(position = 0) {
+    this.durationPreservation.timelinePosition = position;
+    this.durationPreservation.resetPending = false;
+  }
+
+  #isDurationPreservationActive() {
+    return (
+      this.durationPreservation.enabled &&
+      !this.loopEnabled &&
+      Boolean(this.zeroCrossings?.length)
+    );
+  }
+
+  #prepareDurationPreservingSample(playbackRate) {
+    const state = this.durationPreservation;
+
+    if (!this.#isDurationPreservationActive()) return null;
+
+    if (
+      Math.abs(this.playbackPosition - state.timelinePosition) >
+      state.maxDriftSamples
+    ) {
+      state.resetPending = true;
+    }
+
+    if (!state.resetPending) return null;
+
+    const direction = playbackRate < 0 ? 'left' : 'right';
+    const outgoingZero = this.#findNearestZeroCrossing(
+      this.playbackPosition,
+      direction,
+    );
+
+    if (
+      Math.abs(outgoingZero - this.playbackPosition) >
+      Math.abs(playbackRate)
+    ) {
+      return null;
+    }
+
+    this.playbackPosition = outgoingZero;
+    state.resetPending = false;
+    return this.#findNearestZeroCrossing(state.timelinePosition);
+  }
+
+  #advanceDurationPreservingPlayback(playbackRate, resetTarget) {
+    const state = this.durationPreservation;
+
+    this.playbackPosition =
+      resetTarget === null
+        ? this.playbackPosition + playbackRate
+        : resetTarget;
+
+    if (this.#isDurationPreservationActive()) {
+      state.timelinePosition += playbackRate < 0 ? -1 : 1;
+    }
+  }
+
   /**
    * Generate a new drift amount for the current loop iteration
    * @param {number} driftAmount - Maximum drift amount (0-1)
@@ -843,6 +919,7 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
       this.playbackPosition = this.reversePlayback
         ? playbackRange.endSamples - 1
         : playbackRange.startSamples;
+      this.#resetDurationPreservation(this.playbackPosition);
     }
 
     // ===== AUDIO PROCESSING =====
@@ -864,6 +941,10 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
       const effectiveRate = this.reversePlayback
         ? -Math.abs(baseRate)
         : Math.abs(baseRate);
+      const playbackStep = effectiveRate * this.transpositionPlaybackrate;
+
+      const durationResetTarget =
+        this.#prepareDurationPreservingSample(playbackStep);
 
       // Handle looping
       if (this.loopEnabled && this.loopCount < parameters.maxLoopCount[0]) {
@@ -916,10 +997,14 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
       // Don't stop if we're looping and within the playback range
       const shouldStopForward =
         !this.reversePlayback &&
-        this.playbackPosition >= playbackRange.endSamples;
+        (this.#isDurationPreservationActive()
+          ? this.durationPreservation.timelinePosition
+          : this.playbackPosition) >= playbackRange.endSamples;
       const shouldStopReverse =
         this.reversePlayback &&
-        this.playbackPosition <= playbackRange.startSamples;
+        (this.#isDurationPreservationActive()
+          ? this.durationPreservation.timelinePosition
+          : this.playbackPosition) <= playbackRange.startSamples;
       const isWithinLoop =
         this.loopEnabled &&
         this.playbackPosition >= loopRange.loopStartSamples &&
@@ -1026,7 +1111,10 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
         );
       }
 
-      this.playbackPosition += effectiveRate * this.transpositionPlaybackrate;
+      this.#advanceDurationPreservingPlayback(
+        playbackStep,
+        durationResetTarget,
+      );
     }
 
     // Send position updates if requested

--- a/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
+++ b/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
@@ -122,7 +122,7 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
     // Experimental duration preservation. Kept as one feature state object so
     // it can be extracted from this processor cleanly later.
     this.durationPreservation = {
-      enabled: true,
+      enabled: false,
       maxDriftSamples: Math.floor(sampleRate * 0.04),
       timelinePosition: 0,
       resetPending: false,
@@ -702,8 +702,7 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
     );
 
     if (
-      Math.abs(outgoingZero - this.playbackPosition) >
-      Math.abs(playbackRate)
+      Math.abs(outgoingZero - this.playbackPosition) > Math.abs(playbackRate)
     ) {
       return null;
     }
@@ -717,9 +716,7 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
     const state = this.durationPreservation;
 
     this.playbackPosition =
-      resetTarget === null
-        ? this.playbackPosition + playbackRate
-        : resetTarget;
+      resetTarget === null ? this.playbackPosition + playbackRate : resetTarget;
 
     if (this.#isDurationPreservationActive(loopRange)) {
       state.timelinePosition += playbackRate < 0 ? -1 : 1;

--- a/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
+++ b/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
@@ -165,6 +165,9 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
 
       case 'voice:setBuffer':
         this.#resetState();
+        this.zeroCrossings = [];
+        this.minZeroCrossing = 0;
+        this.maxZeroCrossing = 0;
         this.buffer = null;
         this.buffer = buffer;
 
@@ -709,10 +712,19 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
 
     this.playbackPosition = outgoingZero;
     state.resetPending = false;
-    return this.#findNearestZeroCrossing(state.timelinePosition);
+    return this.#findNearestZeroCrossing(
+      state.timelinePosition,
+      'any',
+      state.maxDriftSamples,
+    );
   }
 
-  #advanceDurationPreservingPlayback(playbackRate, resetTarget, loopRange) {
+  #advanceDurationPreservingPlayback(
+    playbackRate,
+    resetTarget,
+    loopRange,
+    canWrapLoop,
+  ) {
     const state = this.durationPreservation;
 
     this.playbackPosition =
@@ -722,13 +734,13 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
       state.timelinePosition += playbackRate < 0 ? -1 : 1;
 
       if (
-        this.loopEnabled &&
+        canWrapLoop &&
         playbackRate >= 0 &&
         state.timelinePosition >= loopRange.loopEndSamples
       ) {
         state.timelinePosition = loopRange.loopStartSamples;
       } else if (
-        this.loopEnabled &&
+        canWrapLoop &&
         playbackRate < 0 &&
         state.timelinePosition <= loopRange.loopStartSamples
       ) {
@@ -956,7 +968,9 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
       const playbackStep = effectiveRate * this.transpositionPlaybackrate;
 
       // Handle looping
-      if (this.loopEnabled && this.loopCount < parameters.maxLoopCount[0]) {
+      const canWrapLoop =
+        this.loopEnabled && this.loopCount < parameters.maxLoopCount[0];
+      if (canWrapLoop) {
         if (
           !this.reversePlayback &&
           this.playbackPosition >= loopRange.loopEndSamples
@@ -1129,6 +1143,7 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
         playbackStep,
         durationResetTarget,
         loopRange,
+        canWrapLoop,
       );
     }
 

--- a/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
+++ b/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
@@ -746,6 +746,8 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
       ) {
         state.timelinePosition = loopRange.loopEndSamples - 1;
       }
+    } else {
+      this.#resetDurationPreservation(this.playbackPosition);
     }
   }
 

--- a/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
+++ b/packages/audiolib/src/worklets/processors/play/sample-player-processor.js
@@ -672,18 +672,19 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
     this.durationPreservation.resetPending = false;
   }
 
-  #isDurationPreservationActive() {
+  #isDurationPreservationActive(loopRange) {
     return (
       this.durationPreservation.enabled &&
-      !this.loopEnabled &&
-      Boolean(this.zeroCrossings?.length)
+      Boolean(this.zeroCrossings?.length) &&
+      (!this.loopEnabled ||
+        loopRange.loopDurationSamples > this.PITCH_PRESERVATION_THRESHOLD)
     );
   }
 
-  #prepareDurationPreservingSample(playbackRate) {
+  #prepareDurationPreservingSample(playbackRate, loopRange) {
     const state = this.durationPreservation;
 
-    if (!this.#isDurationPreservationActive()) return null;
+    if (!this.#isDurationPreservationActive(loopRange)) return null;
 
     if (
       Math.abs(this.playbackPosition - state.timelinePosition) >
@@ -712,7 +713,7 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
     return this.#findNearestZeroCrossing(state.timelinePosition);
   }
 
-  #advanceDurationPreservingPlayback(playbackRate, resetTarget) {
+  #advanceDurationPreservingPlayback(playbackRate, resetTarget, loopRange) {
     const state = this.durationPreservation;
 
     this.playbackPosition =
@@ -720,8 +721,22 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
         ? this.playbackPosition + playbackRate
         : resetTarget;
 
-    if (this.#isDurationPreservationActive()) {
+    if (this.#isDurationPreservationActive(loopRange)) {
       state.timelinePosition += playbackRate < 0 ? -1 : 1;
+
+      if (
+        this.loopEnabled &&
+        playbackRate >= 0 &&
+        state.timelinePosition >= loopRange.loopEndSamples
+      ) {
+        state.timelinePosition = loopRange.loopStartSamples;
+      } else if (
+        this.loopEnabled &&
+        playbackRate < 0 &&
+        state.timelinePosition <= loopRange.loopStartSamples
+      ) {
+        state.timelinePosition = loopRange.loopEndSamples - 1;
+      }
     }
   }
 
@@ -943,9 +958,6 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
         : Math.abs(baseRate);
       const playbackStep = effectiveRate * this.transpositionPlaybackrate;
 
-      const durationResetTarget =
-        this.#prepareDurationPreservingSample(playbackStep);
-
       // Handle looping
       if (this.loopEnabled && this.loopCount < parameters.maxLoopCount[0]) {
         if (
@@ -993,16 +1005,21 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
         }
       }
 
+      const durationResetTarget = this.#prepareDurationPreservingSample(
+        playbackStep,
+        loopRange,
+      );
+
       // Check for end of playback range (forward & reversed)
       // Don't stop if we're looping and within the playback range
       const shouldStopForward =
         !this.reversePlayback &&
-        (this.#isDurationPreservationActive()
+        (this.#isDurationPreservationActive(loopRange)
           ? this.durationPreservation.timelinePosition
           : this.playbackPosition) >= playbackRange.endSamples;
       const shouldStopReverse =
         this.reversePlayback &&
-        (this.#isDurationPreservationActive()
+        (this.#isDurationPreservationActive(loopRange)
           ? this.durationPreservation.timelinePosition
           : this.playbackPosition) <= playbackRange.startSamples;
       const isWithinLoop =
@@ -1114,6 +1131,7 @@ export class SamplePlayerProcessor extends AudioWorkletProcessor {
       this.#advanceDurationPreservingPlayback(
         playbackStep,
         durationResetTarget,
+        loopRange,
       );
     }
 


### PR DESCRIPTION
## What changed

- Add an experimental duration-preservation state to `SamplePlayerProcessor`, enabled for the current proof of concept.
- Track a one-sample-per-frame timeline cursor independently from the playback-rate-driven source cursor.
- Limit source/timeline drift to 40 ms, then resynchronize by jumping between precomputed zero crossings.
- End non-looping playback from the timeline cursor so MIDI pitch transposition retains the selected sample duration.
- Add a `setPreserveDuration` processor message for switching the behavior on or off.
- Preserve duration through ordinary loops by wrapping the timeline cursor independently at the active loop boundaries.
- Continue allowing the pitched source cursor to repeat or drop segments, including interactions with loop-duration keytracking and loop drift.
- Disable duration preservation automatically for short audio-rate loops below the existing pitch-preservation threshold.
- Keep all feature-specific state and helpers together in a dedicated duration-preservation section for straightforward later extraction.

## Why

Pitch transposition currently advances the sample cursor using MIDI-derived playback rate. This couples pitch and duration: higher notes finish sooner and lower notes finish later. The new path provides deliberately rough time-stretched transposition by periodically repeating or dropping source segments at zero crossings while the musical timeline continues at its original rate.

## Impact

The result retains the original sample or loop duration while preserving the existing playback-rate pitch behavior. Artifacts are intentionally acceptable for this proof of concept; zero-crossing resets avoid aggressive discontinuity clicks without adding a granular overlap/add implementation or dependency.

## Validation

- Manually tested in `apps/play` with non-looping and looping samples.
- Manually exercised loop duration through audio-rate ranges, loop-duration keytracking, and loop drift without obvious unwanted glitches.
- `pnpm build --filter @repo/audiolib`
- `node --check packages/audiolib/src/worklets/processors/play/sample-player-processor.js`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an experimental timestretch toggle for sampler playback, with **Warp** and **RePitch** modes.
  * Duration-preserving playback maintains more consistent timing during looping and playback drift.
  * Improved playback correction near zero crossings for smoother transitions.
  * Added support for enabling or disabling timestretch independently across sampler voices.
  * Improved sampler toggle layout and vertical alignment for a cleaner playback controls experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->