### PR TITLE
Add current sample cropping

### DIFF
--- a/apps/play/src/App.tsx
+++ b/apps/play/src/App.tsx
@@ -35,6 +35,7 @@ import {
   recorderInputSource,
   setRecorderInputDeviceId,
 } from './utils/recorderSettings';
+import { setSamplerParamValue } from './utils/samplerParamState';
 
 import { ThemeToggle } from './components/ThemeSwitcher';
 import SaveButton from './components/SaveButton';
@@ -589,7 +590,13 @@ const App: Component = () => {
               <ParamKnob param='trimEnd' player={samplePlayer()} />
               <button
                 class='crop-button'
-                onClick={() => samplePlayer()?.cropSample()}
+                onClick={async () => {
+                  const croppedBuffer = await samplePlayer()?.cropSample();
+                  if (!croppedBuffer) return;
+
+                  setSamplerParamValue('trimStart', 0);
+                  setSamplerParamValue('trimEnd', croppedBuffer.duration);
+                }}
               >
                 Crop
               </button>

--- a/apps/play/src/App.tsx
+++ b/apps/play/src/App.tsx
@@ -591,11 +591,19 @@ const App: Component = () => {
               <button
                 class='crop-button'
                 onClick={async () => {
-                  const croppedBuffer = await samplePlayer()?.cropSample();
-                  if (!croppedBuffer) return;
+                  const player = samplePlayer();
+                  if (!player) return;
 
-                  setSamplerParamValue('trimStart', 0);
-                  setSamplerParamValue('trimEnd', croppedBuffer.duration);
+                  try {
+                    const croppedBuffer = await player.cropSample();
+                    if (!croppedBuffer) return;
+
+                    setSamplerParamValue('trimStart', 0);
+                    setSamplerParamValue('trimEnd', croppedBuffer.duration);
+                  } catch (error) {
+                    console.error('Failed to crop sample:', error);
+                    showNotification('Failed to crop sample');
+                  }
                 }}
               >
                 Crop

--- a/apps/play/src/App.tsx
+++ b/apps/play/src/App.tsx
@@ -587,6 +587,12 @@ const App: Component = () => {
             <div class='expandable-content'>
               <ParamKnob param='trimStart' player={samplePlayer()} />
               <ParamKnob param='trimEnd' player={samplePlayer()} />
+              <button
+                class='crop-button'
+                onClick={() => samplePlayer()?.cropSample()}
+              >
+                Crop
+              </button>
             </div>
           </fieldset>
 

--- a/apps/play/src/hooks/useSampleSelection.ts
+++ b/apps/play/src/hooks/useSampleSelection.ts
@@ -18,16 +18,17 @@ export const useSampleSelection = (
         skipPreProcessing: true,
       });
 
-      if (sample.settings) {
-        const controlsRoot = getControlsRoot();
-        if (controlsRoot) {
-          restoreInstrumentState(
-            samplePlayerRef,
-            controlsRoot,
-            sample.settings,
-          );
-        }
-      }
+      // ! Disabled until audio-elements simplified and state contracts clarified
+      // if (sample.settings) {
+      //   const controlsRoot = getControlsRoot();
+      //   if (controlsRoot) {
+      //     restoreInstrumentState(
+      //       samplePlayerRef,
+      //       controlsRoot,
+      //       sample.settings,
+      //     );
+      //   }
+      // }
 
       setSidebarOpen(false);
     } catch (error) {

--- a/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
+++ b/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
@@ -558,6 +558,9 @@ export class SamplePlayer implements ILibInstrumentNode {
   ): Promise<AudioBuffer | null> {
     const buffer = this.#audiobuffer;
     if (!buffer) return null;
+    if (!Number.isFinite(startSeconds) || !Number.isFinite(endSeconds)) {
+      return null;
+    }
 
     const startSample = Math.max(
       0,

--- a/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
+++ b/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
@@ -497,10 +497,9 @@ export class SamplePlayer implements ILibInstrumentNode {
 
     try {
       if (buffer instanceof ArrayBuffer) {
-        const ctx = getAudioContext();
         // decodeAudioData detaches its input; copy so callers can safely
         // reuse/re-pass the same ArrayBuffer (e.g. re-selecting a cached sample).
-        buffer = await ctx.decodeAudioData(buffer.slice(0));
+        buffer = await this.context.decodeAudioData(buffer.slice(0));
       }
 
       if (!isValidAudioBuffer(buffer)) {
@@ -516,7 +515,7 @@ export class SamplePlayer implements ILibInstrumentNode {
 
       if (modSampleRate && this.context.sampleRate !== modSampleRate) {
         console.warn(
-          `Sample rate mismatch: buffer rate ${buffer.sampleRate}, context rate ${this.context.sampleRate}, requested rate ${modSampleRate}`,
+          `Sample rate mismatch: context rate ${this.context.sampleRate}, requested rate ${modSampleRate}`,
         );
       }
 

--- a/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
+++ b/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
@@ -3,6 +3,7 @@
 import { getAudioContext } from '@/context';
 import { Message, MessageHandler } from '@/events';
 import { detectSinglePitchAC } from '@/utils/audiodata/pitchDetection';
+import { trimAudioBuffer } from '@/utils/audiodata/process/trimBuffer';
 import { clamp, findClosestNote, ROOT_NOTES } from '@/utils';
 import { Debouncer } from '@/utils/Debouncer';
 
@@ -550,6 +551,38 @@ export class SamplePlayer implements ILibInstrumentNode {
     return buffer;
   }
 
+  async cropSample(
+    startSeconds = this.getStartPoint(),
+    endSeconds = this.getEndPoint(),
+    fadeMs = 4,
+  ): Promise<AudioBuffer | null> {
+    const buffer = this.#audiobuffer;
+    if (!buffer) return null;
+
+    const startSample = Math.max(
+      0,
+      Math.floor(startSeconds * buffer.sampleRate),
+    );
+    const endSample = Math.min(
+      buffer.length,
+      Math.ceil(endSeconds * buffer.sampleRate),
+    );
+
+    if (endSample <= startSample) return null;
+
+    const croppedBuffer = trimAudioBuffer(
+      this.context,
+      buffer,
+      startSample,
+      endSample,
+      fadeMs,
+    );
+
+    return this.loadSample(croppedBuffer, undefined, {
+      skipPreProcessing: true,
+    });
+  }
+
   async detectPitch(buffer: AudioBuffer) {
     const pitchSource = await detectSinglePitchAC(buffer);
     const targetNoteInfo = findClosestNote(pitchSource.frequency);
@@ -1031,18 +1064,13 @@ export class SamplePlayer implements ILibInstrumentNode {
 
   /** PARAM GETTERS  */
 
+  // TODO: Consider moving source of truth from SampleVoice to SamplePlayer, or convert to MacroParams, symmetrical with the loop start/end points
   getStartPoint(): number {
-    return this.getStoredParamValue(
-      'startPoint',
-      DEFAULT_PARAM_DESCRIPTORS.START_POINT.defaultValue,
-    );
+    return this.voicePool?.allVoices[0]?.startPoint ?? 0;
   }
 
   getEndPoint(): number {
-    return this.getStoredParamValue(
-      'endPoint',
-      DEFAULT_PARAM_DESCRIPTORS.END_POINT.defaultValue,
-    );
+    return this.voicePool?.allVoices[0]?.endPoint ?? this.sampleDuration;
   }
 
   getLoopRampDuration(): number {

--- a/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
+++ b/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
@@ -482,73 +482,93 @@ export class SamplePlayer implements ILibInstrumentNode {
 
   /* === LOAD / RESET === */
 
+  #isLoading = false;
+
   async loadSample(
     buffer: AudioBuffer | ArrayBuffer,
     modSampleRate?: number,
     preprocessOptions?: Partial<PreProcessOptions>,
   ): Promise<AudioBuffer | null> {
-    if (buffer instanceof ArrayBuffer) {
-      const ctx = getAudioContext();
-      // decodeAudioData detaches its input; copy so callers can safely
-      // reuse/re-pass the same ArrayBuffer (e.g. re-selecting a cached sample).
-      buffer = await ctx.decodeAudioData(buffer.slice(0));
+    if (this.#isLoading) {
+      throw new Error('A sample load is already in progress');
     }
+    this.#isLoading = true;
+    let unsubscribe: (() => void) | undefined;
 
-    if (!isValidAudioBuffer(buffer)) {
-      console.error('Invalid AudioBuffer provided to loadSample');
-      return null;
-    }
-
-    if (
-      buffer.sampleRate !== this.context.sampleRate ||
-      (modSampleRate && this.context.sampleRate !== modSampleRate)
-    ) {
-      console.warn(
-        `sample rate mismatch, 
-        buffer rate: ${buffer.sampleRate}, 
-        context rate: ${this.context.sampleRate}
-        requested rate: ${modSampleRate}`,
-      );
-    }
-
-    this.releaseAll(0);
-    this.transposeSemitones = 0;
-    this.#isLoaded = false;
-    this.#audiobuffer = null;
-
-    let processed: PreProcessResults | undefined;
-
-    if (this.#preprocessAudio) {
-      processed = await preProcessAudioBuffer(
-        this.context,
-        buffer,
-        preprocessOptions,
-      );
-      buffer = processed.audiobuffer;
-
-      if (this.#useZeroCrossings && processed.zeroCrossings) {
-        this.#zeroCrossings = processed.zeroCrossings;
+    try {
+      if (buffer instanceof ArrayBuffer) {
+        const ctx = getAudioContext();
+        // decodeAudioData detaches its input; copy so callers can safely
+        // reuse/re-pass the same ArrayBuffer (e.g. re-selecting a cached sample).
+        buffer = await ctx.decodeAudioData(buffer.slice(0));
       }
+
+      if (!isValidAudioBuffer(buffer)) {
+        console.error('Invalid AudioBuffer provided to loadSample');
+        return null;
+      }
+
+      if (buffer.sampleRate !== this.context.sampleRate) {
+        throw new RangeError(
+          `Sample rate mismatch: buffer rate ${buffer.sampleRate}, context rate ${this.context.sampleRate}`,
+        );
+      }
+
+      if (modSampleRate && this.context.sampleRate !== modSampleRate) {
+        console.warn(
+          `Sample rate mismatch: buffer rate ${buffer.sampleRate}, context rate ${this.context.sampleRate}, requested rate ${modSampleRate}`,
+        );
+      }
+
+      this.releaseAll(0);
+      this.transposeSemitones = 0;
+      this.#isLoaded = false;
+      this.#audiobuffer = null;
+
+      let processed: PreProcessResults | undefined;
+
+      if (this.#preprocessAudio) {
+        processed = await preProcessAudioBuffer(
+          this.context,
+          buffer,
+          preprocessOptions,
+        );
+        buffer = processed.audiobuffer;
+
+        if (this.#useZeroCrossings && processed.zeroCrossings) {
+          this.#zeroCrossings = processed.zeroCrossings;
+        }
+      }
+
+      this.#audiobuffer = buffer;
+      this.#bufferDuration = buffer.duration;
+
+      const loadedPromise = new Promise<void>((resolve) => {
+        unsubscribe = this.voicePool.onMessage('sample:loaded', () => {
+          resolve();
+        });
+      });
+
+      this.voicePool.setBuffer(buffer, this.#zeroCrossings);
+      this.#resetMacros();
+
+      const defaultScaleOptions = {
+        rootNote: 'C' as keyof typeof ROOT_NOTES,
+        scale: [0],
+        lowestOctave: 0,
+        highestOctave: 5,
+        tuningOffset: 0,
+        normalize: false as NormalizeOptions | false,
+      };
+
+      this.setScale(defaultScaleOptions);
+
+      await loadedPromise;
+      return buffer;
+    } finally {
+      unsubscribe?.();
+      this.#isLoading = false;
     }
-
-    this.#audiobuffer = buffer;
-    this.#bufferDuration = buffer.duration;
-
-    this.voicePool.setBuffer(buffer, this.#zeroCrossings);
-    this.#resetMacros();
-
-    const defaultScaleOptions = {
-      rootNote: 'C' as keyof typeof ROOT_NOTES,
-      scale: [0],
-      lowestOctave: 0,
-      highestOctave: 5,
-      tuningOffset: 0,
-      normalize: false as NormalizeOptions | false,
-    };
-
-    this.setScale(defaultScaleOptions);
-
-    return buffer;
   }
 
   async cropSample(


### PR DESCRIPTION
## What changed

- Add `SamplePlayer.cropSample()` to replace the current sample with its selected start/end range.
- Default cropping to the live start and end points from the sample voices, while allowing callers to provide explicit points.
- Reload the cropped buffer through the existing sample-loading lifecycle so voices, duration, zero crossings, and downstream `sample:loaded` consumers update normally.
- Add a Crop button to the Play app's trim controls.

## Why

Start and end controls previously limited playback non-destructively, but there was no way to commit that selection as the new current sample. This adds the smallest end-to-end path by reusing audiolib's existing buffer trimming and sample-loading architecture.

## Deferred follow-up

The existing `trimAudioBuffer` utility is intentionally unchanged in this PR. Its API and behavior need a separate design pass, including independent fade-in/fade-out controls, sample-based fade units, validation and fade behavior, and a documented, consistent convention for inclusive or exclusive end samples across audiolib.

Tracked in #190.

## Validation

- `pnpm -C packages/audiolib test` — 116 passed, 1 skipped
- `pnpm -C packages/audiolib exec tsc --noEmit`
- `pnpm -C apps/play exec tsc --noEmit`
- `git diff --check origin/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Crop** button to the Trim controls.
  * Crop audio samples using selected trim boundaries, with optional fade support.
  * Trim boundaries automatically update to match the cropped sample’s duration.

* **Bug Fixes**
  * Trim boundaries now accurately reflect the currently loaded sample.
  * Improved sample loading reliability and validation.
  * Crop failures are reported through an on-screen notification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->