### PR TITLE
Normalize sample-duration-relative knob params to 0..1

### DIFF
--- a/apps/play/src/App.tsx
+++ b/apps/play/src/App.tsx
@@ -562,8 +562,9 @@ const App: Component = () => {
                     const croppedBuffer = await player.cropSample();
                     if (!croppedBuffer) return;
 
+                    // Trim points are normalized: the crop is the new full range.
                     setSamplerParamValue('trimStart', 0);
-                    setSamplerParamValue('trimEnd', croppedBuffer.duration);
+                    setSamplerParamValue('trimEnd', 1);
                   } catch (error) {
                     console.error('Failed to crop sample:', error);
                     showNotification('Failed to crop sample');

--- a/apps/play/src/components/knobs/ParamKnob.tsx
+++ b/apps/play/src/components/knobs/ParamKnob.tsx
@@ -34,6 +34,7 @@ interface ParamKnobProps {
 export const ParamKnob: Component<ParamKnobProps> = (props) => {
   const desc: SamplerParamDescriptor = samplerParams[props.param];
   const [dimmed, setDimmed] = createSignal(false);
+  const [sampleDuration, setSampleDuration] = createSignal(0);
   const value = () => samplerParamValues()[props.param];
 
   let containerRef: HTMLDivElement | undefined;
@@ -81,33 +82,21 @@ export const ParamKnob: Component<ParamKnobProps> = (props) => {
     desc.apply(player, nextValue);
   });
 
-  // On player ready, wire up dynamic max (sample-length-relative params) to
-  // follow the loaded sample. These listeners must not be recreated when the
-  // knob value changes.
+  // On player ready, track the loaded sample's duration for the seconds
+  // readout of normalized params. These listeners must not be recreated when
+  // the knob value changes.
   createEffect(() => {
     const player = props.player;
     if (!player) return;
 
     const unsubscribe: Array<() => void> = [];
 
-    if (desc.getMax) {
-      const updateMax = (durationSeconds: number) => {
-        if (!knobEl || durationSeconds <= 0) return;
-        knobEl.setAttribute('max-value', durationSeconds.toString());
-        // Params whose default means "full sample length" (trimEnd,
-        // loopDuration) also track the duration as their default.
-        if (desc.defaultValue === desc.max) {
-          knobEl.setAttribute('default-value', durationSeconds.toString());
-        }
-      };
-
-      updateMax(desc.getMax(player));
-      unsubscribe.push(
-        player.onMessage('sample:loaded', (msg: any) =>
-          updateMax(msg.durationSeconds),
-        ),
-      );
-    }
+    setSampleDuration(player.sampleDuration);
+    unsubscribe.push(
+      player.onMessage('sample:loaded', (msg: any) =>
+        setSampleDuration(msg.durationSeconds),
+      ),
+    );
 
     // Keytrack has no audible effect when the loop is off or audio-rate
     // (<= PITCH_PRESERVATION_THRESHOLD in the processor): dim as a hint.
@@ -138,7 +127,9 @@ export const ParamKnob: Component<ParamKnobProps> = (props) => {
   });
 
   const label = () => props.label ?? desc.label;
-  const format = desc.format ?? ((v: number) => v.toFixed(2));
+  const format =
+    desc.format ?? ((v: number, _duration: number) => v.toFixed(2));
+  const readout = () => format(value(), sampleDuration());
 
   return (
     <div
@@ -149,7 +140,7 @@ export const ParamKnob: Component<ParamKnobProps> = (props) => {
     >
       <div class={styles.knobLabel}>{label()}</div>
       <div ref={containerRef} />
-      <div class={styles.knobValue}>{format(value())}</div>
+      <div class={styles.knobValue}>{readout()}</div>
     </div>
   );
 };

--- a/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
+++ b/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
@@ -104,15 +104,10 @@ export class SamplePlayer implements ILibInstrumentNode {
 
     this.#masterOut = new GainNode(this.context, { gain: 0.5 });
 
-    this.#macroLoopStart = new MacroParam(
-      this.context,
-      samplerParams.loopStart.defaultValue,
-    );
-
-    this.#macroLoopEnd = new MacroParam(
-      this.context,
-      samplerParams.loopEnd.defaultValue,
-    );
+    // Seconds; the real loop range is set from the buffer duration in
+    // #resetMacros once a sample is loaded.
+    this.#macroLoopStart = new MacroParam(this.context, 0);
+    this.#macroLoopEnd = new MacroParam(this.context, 0);
 
     // Store configuration for async init
     this.#polyphony = polyphony;

--- a/packages/audiolib/src/nodes/instruments/Sample/sampler-params.ts
+++ b/packages/audiolib/src/nodes/instruments/Sample/sampler-params.ts
@@ -15,14 +15,14 @@ export interface SamplerParamDescriptor {
   step?: number;
   /** Discrete values only (e.g. pitch scale ratios) */
   allowedValues?: readonly number[];
-  format?: (value: number) => string;
-  /** Live max for sample-length-relative params (seconds). Overrides `max` once a sample is loaded. */
-  getMax?: (player: SamplePlayer) => number;
+  format?: (value: number, sampleDurationSeconds: number) => string;
   apply: (player: SamplePlayer, value: number) => void;
 }
 
 const pct = (v: number) => `${(v * 100).toFixed(0)}%`;
 const hz = (v: number) => `${v.toFixed(0)} Hz`;
+/** Normalized position -> seconds readout */
+const seconds = (v: number, duration: number) => `${(v * duration).toFixed(2)} s`;
 
 export const samplerParams = {
   volume: {
@@ -225,15 +225,16 @@ export const samplerParams = {
     apply: (p, v) => p.pitchLFO?.setDepth(v / 10),
   },
 
-  // Trim / loop (seconds, max follows loaded sample duration)
+  // Trim / loop. Normalized 0..1 as a fraction of the loaded sample's duration:
+  // apply() converts to seconds, so the control range never depends on the sample.
   trimStart: {
     label: 'Start',
     min: 0,
     max: 1,
     defaultValue: 0,
     step: 0.001,
-    getMax: (p) => p.sampleDuration,
-    apply: (p, v) => p.setSampleStartPoint(v),
+    format: seconds,
+    apply: (p, v) => p.setSampleStartPoint(v * p.sampleDuration),
   },
   trimEnd: {
     label: 'End',
@@ -241,8 +242,8 @@ export const samplerParams = {
     max: 1,
     defaultValue: 1,
     step: 0.001,
-    getMax: (p) => p.sampleDuration,
-    apply: (p, v) => p.setSampleEndPoint(v),
+    format: seconds,
+    apply: (p, v) => p.setSampleEndPoint(v * p.sampleDuration),
   },
   loopStart: {
     label: 'Loop Start',
@@ -250,8 +251,8 @@ export const samplerParams = {
     max: 1,
     defaultValue: 0,
     step: 0.001,
-    getMax: (p) => p.sampleDuration,
-    apply: (p, v) => p.setLoopStart(v),
+    format: seconds,
+    apply: (p, v) => p.setLoopStart(v * p.sampleDuration),
   },
   loopDuration: {
     label: 'Loop Length',
@@ -259,10 +260,11 @@ export const samplerParams = {
     max: 1,
     defaultValue: 1,
     curve: 4,
-    getMax: (p) => p.sampleDuration,
-    format: (v) =>
-      v <= 0.061 ? `${(v * 1000).toFixed(0)}ms` : `${v.toFixed(2)} s`,
-    apply: (p, v) => p.setLoopDuration(v),
+    format: (v, duration) => {
+      const s = v * duration;
+      return s <= 0.061 ? `${(s * 1000).toFixed(0)}ms` : `${s.toFixed(2)} s`;
+    },
+    apply: (p, v) => p.setLoopDuration(v * p.sampleDuration),
   },
   // Todo: Decide whether all params should be returned or just those requested by app (add param?)
   loopEnd: {
@@ -271,8 +273,8 @@ export const samplerParams = {
     max: 1,
     defaultValue: 1,
     step: 0.001,
-    getMax: (p) => p.sampleDuration,
-    apply: (p, v) => p.setLoopEnd(v),
+    format: seconds,
+    apply: (p, v) => p.setLoopEnd(v * p.sampleDuration),
   },
   loopRampDuration: {
     label: 'Loop Ramp',


### PR DESCRIPTION
## Problem

On reload, Loop Length and End never returned to their maximum and got lower on every reload.

`trimStart/trimEnd/loopStart/loopDuration/loopEnd` were stored in seconds while their descriptor `max` stayed `1`, so `ParamKnob` rewrote the knob's `max-value` once a sample loaded. `KnobElement.attributeChangedCallback` rescales its current value proportionally from the old range to the new one and dispatches `knob-change`, which persisted the scaled value — so each reload multiplied the stored value by the sample duration. With a sample longer than 1s it ratcheted up until it clamped; under 1s it decayed geometrically.

Measured before the fix: a stored `0.4` came back as `0.7208416666` after one reload, exactly `0.4 x 1.8021041666` (the sample duration).

## Change

The conversion boundary is now `SamplePlayer`, the lowest layer that knows the buffer duration:

- Duration-relative descriptors hold a normalized 0..1 fraction; `apply()` multiplies by `p.sampleDuration`. `getMax` is gone from the descriptor type and all five params.
- `format` takes `(value, sampleDurationSeconds)` so the readout stays in seconds; `loopDuration` converts before its ms/s threshold.
- `ParamKnob` no longer rewrites `max-value`/`default-value`. Its `sample:loaded` subscription now only feeds a `sampleDuration` signal for the readout.
- Crop resets trim to `0`/`1` — the crop is the new full range.
- Loop macros init to `0` seconds instead of borrowing the (now normalized) descriptor defaults; `#resetMacros` sets the real range on load.

Everything below `SamplePlayer` still works in seconds and is untouched: tempo-sync, `MIN_LOOP_DURATION_SECONDS`, loop ramp/glide, the worklet params, `EnvelopeSVG` and `SampleControls`.

## Verification

`tsc --noEmit` passes for `@repo/audiolib` and `play`. Checked against the running dev app:

- fresh state: trim/loop knobs sit at `1` with `1.80 s` / `0.00 s` readouts, `max-value` fixed at `1`
- a stored `0.4` survives a reload as `0.4`, reading `0.72 s` (previously `0.7208...`, then compounding)

## Follow-ups

Deferred items — stale seconds-valued stored values, the sample-change policy, the `KnobElement` rescale itself, and the duplicate legacy knob/envelope paths — are tracked in #195 for the persistence slice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sample trim and loop controls to remain accurate after cropping.
  * Trim and loop positions now display relative to the loaded sample’s duration.
  * Very short loop durations are shown in milliseconds for easier precision.
  * Sample playback now initializes loop boundaries consistently when loading audio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->