### PR TITLE
Make PWA update checks reliable on iOS

### DIFF
--- a/apps/play/src/utils/pwa-utils/updateSW.ts
+++ b/apps/play/src/utils/pwa-utils/updateSW.ts
@@ -11,12 +11,23 @@ registerSW({
 
     const check = async () => {
       if (registration.installing || !navigator.onLine) return;
-      // ponytail: no-store fetch first so a cached sw.js can't mask an update
+      // Fetch sw.js with no-store first: an HTTP-cached copy would otherwise
+      // look unchanged to update() and the app would stay on the old version.
       const resp = await fetch(swUrl, {
         cache: 'no-store',
         headers: { cache: 'no-store', 'cache-control': 'no-cache' },
-      }).catch(() => null);
-      if (resp?.status === 200) await registration.update().catch(() => {});
+      }).catch((err) => {
+        console.warn('[pwa] sw.js check failed', err);
+        return null;
+      });
+      if (!resp) return;
+      if (resp.status !== 200) {
+        console.warn('[pwa] sw.js returned', resp.status, '- update skipped');
+        return;
+      }
+      await registration
+        .update()
+        .catch((err) => console.warn('[pwa] sw update failed', err));
     };
 
     setInterval(check, intervalMS);

--- a/apps/play/src/utils/pwa-utils/updateSW.ts
+++ b/apps/play/src/utils/pwa-utils/updateSW.ts
@@ -6,11 +6,25 @@ const intervalMS = 60 * 60 * 1000;
 // reloads only once the new worker has actually activated.
 registerSW({
   immediate: true,
-  onRegistered(registration) {
+  onRegisteredSW(swUrl, registration) {
     if (!registration) return;
-    setInterval(() => registration.update(), intervalMS);
+
+    const check = async () => {
+      if (registration.installing || !navigator.onLine) return;
+      // ponytail: no-store fetch first so a cached sw.js can't mask an update
+      const resp = await fetch(swUrl, {
+        cache: 'no-store',
+        headers: { cache: 'no-store', 'cache-control': 'no-cache' },
+      }).catch(() => null);
+      if (resp?.status === 200) await registration.update().catch(() => {});
+    };
+
+    setInterval(check, intervalMS);
+    // pageshow covers iOS standalone resume from bfcache, where
+    // visibilitychange alone is unreliable.
+    window.addEventListener('pageshow', check);
     document.addEventListener('visibilitychange', () => {
-      if (document.visibilityState === 'visible') registration.update();
+      if (document.visibilityState === 'visible') check();
     });
   },
 });


### PR DESCRIPTION
Use onRegisteredSW with a no-store fetch of sw.js so an HTTP-cached worker can't mask an update, and trigger checks on pageshow as well as visibilitychange (iOS standalone resumes from bfcache).

Possible follow-up: https://github.com/KristinnRoach/sampler-monorepo/issues/197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service worker update checks to avoid unnecessary or unsafe update attempts.
  * Updates are now skipped when the app is offline, installing, or no registration is available.
  * Added validation before applying updates to ensure the service worker is available.
  * Added reliable update checks when returning to the app, becoming visible, and at regular intervals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->