### PR TITLE
Keep sampler loop points consistent

### DIFF
--- a/apps/play/src/App.tsx
+++ b/apps/play/src/App.tsx
@@ -119,7 +119,7 @@ const App: Component = () => {
       // SamplePlayer resets its loop/trim points to the full buffer on load,
       // so reset the normalized controls to match instead of keeping the
       // previous sample's fractions.
-      (['trimStart', 'trimEnd', 'loopStart', 'loopDuration'] as const).forEach(
+      (['trimStart', 'trimEnd', 'loopStart', 'loopEnd'] as const).forEach(
         (key) => setSamplerParamValue(key, samplerParams[key].defaultValue),
       );
 
@@ -536,11 +536,7 @@ const App: Component = () => {
                 label='Start'
                 player={samplePlayer()}
               />
-              <ParamKnob
-                param='loopDuration'
-                label='Duration'
-                player={samplePlayer()}
-              />
+              <ParamKnob param='loopEnd' label='End' player={samplePlayer()} />
               <ParamKnob
                 param='keytrackLoop'
                 label='KeyTrack'

--- a/apps/play/src/App.tsx
+++ b/apps/play/src/App.tsx
@@ -58,10 +58,17 @@ import SamplerToggle from './components/SamplerToggle';
 export const [samplePlayer, setSamplePlayer] =
   createSignal<SamplePlayer | null>(null);
 
-const LOOP_POINT_GAP = Math.max(
-  samplerParams.loopStart.step ?? 0,
-  samplerParams.loopEnd.step ?? 0,
-);
+// Todo: Provide a simpler solution from audiolib's params API
+const getLoopPointGap = () => {
+  const step = Math.max(
+    samplerParams.loopStart.step ?? 0,
+    samplerParams.loopEnd.step ?? 0,
+  );
+  const player = getSamplePlayer();
+  const minLoopSec = player ? player.MIN_LOOP_DURATION_SECONDS : 1 / 523.25;
+  const duration = Math.max(player?.sampleDuration ?? 1, minLoopSec);
+  return Math.max(step, minLoopSec / duration);
+};
 
 // Untracked read for non-reactive consumers (web components, MidiMan, etc.)
 export const getSamplePlayer = () => samplePlayer();
@@ -544,7 +551,7 @@ const App: Component = () => {
                 label='Start'
                 player={samplePlayer()}
                 maxAllowed={() =>
-                  samplerParamValues().loopEnd - LOOP_POINT_GAP
+                  samplerParamValues().loopEnd - getLoopPointGap()
                 }
               />
               <ParamKnob
@@ -552,7 +559,7 @@ const App: Component = () => {
                 label='End'
                 player={samplePlayer()}
                 minAllowed={() =>
-                  samplerParamValues().loopStart + LOOP_POINT_GAP
+                  samplerParamValues().loopStart + getLoopPointGap()
                 }
               />
               <ParamKnob

--- a/apps/play/src/App.tsx
+++ b/apps/play/src/App.tsx
@@ -39,7 +39,10 @@ import {
   recorderInputSource,
   setRecorderInputDeviceId,
 } from './utils/recorderSettings';
-import { setSamplerParamValue } from './utils/samplerParamState';
+import {
+  samplerParamValues,
+  setSamplerParamValue,
+} from './utils/samplerParamState';
 
 import { ThemeToggle } from './components/ThemeSwitcher';
 import SaveButton from './components/SaveButton';
@@ -54,6 +57,11 @@ import SamplerToggle from './components/SamplerToggle';
 
 export const [samplePlayer, setSamplePlayer] =
   createSignal<SamplePlayer | null>(null);
+
+const LOOP_POINT_GAP = Math.max(
+  samplerParams.loopStart.step ?? 0,
+  samplerParams.loopEnd.step ?? 0,
+);
 
 // Untracked read for non-reactive consumers (web components, MidiMan, etc.)
 export const getSamplePlayer = () => samplePlayer();
@@ -535,8 +543,18 @@ const App: Component = () => {
                 param='loopStart'
                 label='Start'
                 player={samplePlayer()}
+                maxAllowed={() =>
+                  samplerParamValues().loopEnd - LOOP_POINT_GAP
+                }
               />
-              <ParamKnob param='loopEnd' label='End' player={samplePlayer()} />
+              <ParamKnob
+                param='loopEnd'
+                label='End'
+                player={samplePlayer()}
+                minAllowed={() =>
+                  samplerParamValues().loopStart + LOOP_POINT_GAP
+                }
+              />
               <ParamKnob
                 param='keytrackLoop'
                 label='KeyTrack'

--- a/apps/play/src/components/knobs/ParamKnob.tsx
+++ b/apps/play/src/components/knobs/ParamKnob.tsx
@@ -40,7 +40,17 @@ export const ParamKnob: Component<ParamKnobProps> = (props) => {
   let containerRef: HTMLDivElement | undefined;
   let knobEl: KnobElement | undefined;
   const handleChange = (e: Event) => {
-    const val = (e as CustomEvent<{ value: number }>).detail.value;
+    let val = (e as CustomEvent<{ value: number }>).detail.value;
+    const values = samplerParamValues();
+    const gap = desc.step ?? 0;
+
+    if (props.param === 'loopStart') {
+      val = Math.max(desc.min, Math.min(val, values.loopEnd - gap));
+    }
+    if (props.param === 'loopEnd') {
+      val = Math.min(desc.max, Math.max(val, values.loopStart + gap));
+    }
+
     setSamplerParamValue(props.param, val);
   };
 
@@ -100,8 +110,7 @@ export const ParamKnob: Component<ParamKnobProps> = (props) => {
 
     // Keytrack has no audible effect when the loop is off or audio-rate
     // (<= PITCH_PRESERVATION_THRESHOLD in the processor): dim as a hint.
-    // The loopStart/loopEnd getters lag (macro ramps async), so prefer the
-    // message payload's target values when present.
+    // The message keeps this hint reactive when either loop target changes.
     if (props.param === 'keytrackLoop') {
       const AUDIO_RATE_SECONDS = 0.061;
       const updateHint = (msg?: { loopStart: number; loopEnd: number }) => {

--- a/apps/play/src/components/knobs/ParamKnob.tsx
+++ b/apps/play/src/components/knobs/ParamKnob.tsx
@@ -40,18 +40,26 @@ export const ParamKnob: Component<ParamKnobProps> = (props) => {
   let containerRef: HTMLDivElement | undefined;
   let knobEl: KnobElement | undefined;
   const handleChange = (e: Event) => {
-    let val = (e as CustomEvent<{ value: number }>).detail.value;
+    const requestedValue = (e as CustomEvent<{ value: number }>).detail.value;
     const values = samplerParamValues();
     const gap = desc.step ?? 0;
 
+    let clampedValue = requestedValue;
     if (props.param === 'loopStart') {
-      val = Math.max(desc.min, Math.min(val, values.loopEnd - gap));
+      clampedValue = Math.max(
+        desc.min,
+        Math.min(clampedValue, values.loopEnd - gap),
+      );
     }
     if (props.param === 'loopEnd') {
-      val = Math.min(desc.max, Math.max(val, values.loopStart + gap));
+      clampedValue = Math.min(
+        desc.max,
+        Math.max(clampedValue, values.loopStart + gap),
+      );
     }
 
-    setSamplerParamValue(props.param, val);
+    setSamplerParamValue(props.param, clampedValue);
+    if (clampedValue !== requestedValue) knobEl?.setValue(clampedValue);
   };
 
   onMount(() => {

--- a/apps/play/src/components/knobs/ParamKnob.tsx
+++ b/apps/play/src/components/knobs/ParamKnob.tsx
@@ -29,6 +29,8 @@ interface ParamKnobProps {
   size?: number;
   class?: string;
   title?: string;
+  minAllowed?: () => number;
+  maxAllowed?: () => number;
 }
 
 export const ParamKnob: Component<ParamKnobProps> = (props) => {
@@ -41,22 +43,12 @@ export const ParamKnob: Component<ParamKnobProps> = (props) => {
   let knobEl: KnobElement | undefined;
   const handleChange = (e: Event) => {
     const requestedValue = (e as CustomEvent<{ value: number }>).detail.value;
-    const values = samplerParamValues();
-    const gap = desc.step ?? 0;
-
-    let clampedValue = requestedValue;
-    if (props.param === 'loopStart') {
-      clampedValue = Math.max(
-        desc.min,
-        Math.min(clampedValue, values.loopEnd - gap),
-      );
-    }
-    if (props.param === 'loopEnd') {
-      clampedValue = Math.min(
-        desc.max,
-        Math.max(clampedValue, values.loopStart + gap),
-      );
-    }
+    const minAllowed = Math.max(desc.min, props.minAllowed?.() ?? desc.min);
+    const maxAllowed = Math.min(desc.max, props.maxAllowed?.() ?? desc.max);
+    const clampedValue = Math.max(
+      minAllowed,
+      Math.min(requestedValue, maxAllowed),
+    );
 
     setSamplerParamValue(props.param, clampedValue);
     if (clampedValue !== requestedValue) knobEl?.setValue(clampedValue);

--- a/packages/audio-components/src/elements/Sampler/components/SamplerKnobFactory.ts
+++ b/packages/audio-components/src/elements/Sampler/components/SamplerKnobFactory.ts
@@ -291,9 +291,8 @@ const keytrackLoopConfig: KnobConfig = {
 
     // Dim when keytrack has no effect: loop off, or loop audio-rate
     // (<= PITCH_PRESERVATION_THRESHOLD). Stays live via loop:enabled / loop-points:updated.
-    // NOTE: the sampler.loopEnd/loopStart getters lag (macro ramps async); the message
-    // payload carries the authoritative target, so prefer it when present. loopEnabled
-    // getter is synchronous, so it's read directly.
+    // Prefer the message payload so this hint updates reactively with loop targets.
+    // loopEnabled is read directly because its getter is synchronous.
     const AUDIO_RATE_SECONDS = 0.061;
     const updateHint = (msg?: { loopStart: number; loopEnd: number }) => {
       if (!knobElement) return;

--- a/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
+++ b/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
@@ -943,11 +943,14 @@ export class SamplePlayer implements ILibInstrumentNode {
     loopEndSeconds: number,
     rampDuration: number = this.getLoopRampDuration(),
   ) {
-    let loopStart = clamp(
-      loopStartSeconds,
-      0 + this.MIN_LOOP_DURATION_SECONDS / 2,
-      loopEndSeconds,
-    );
+    let loopStart =
+      loopPoint === 'start'
+        ? clamp(
+            loopStartSeconds,
+            this.MIN_LOOP_DURATION_SECONDS / 2,
+            loopEndSeconds,
+          )
+        : loopStartSeconds;
 
     if (loopPoint === 'start' && loopStart === this.loopStart) return this;
 

--- a/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
+++ b/packages/audiolib/src/nodes/instruments/Sample/SamplePlayer.ts
@@ -974,17 +974,12 @@ export class SamplePlayer implements ILibInstrumentNode {
         loopStart = loopEnd - numBeats * beatDuration;
       }
 
-      const storeLoopStart = () => this.storeParamValue('loopStart', loopStart);
-
       if (targetLoopDuration < this.MIN_LOOP_DURATION_SECONDS) {
         loopStart = loopEnd - this.MIN_LOOP_DURATION_SECONDS;
       }
 
-      this.#macroLoopStart.ramp(loopStart, scaledRampTime, loopEnd, {
-        onComplete: () => {
-          storeLoopStart();
-        },
-      });
+      this.#macroLoopStart.ramp(loopStart, scaledRampTime, loopEnd);
+      this.storeParamValue('loopStart', this.loopStart);
     } else if (loopPoint === 'end' && loopEnd !== this.loopEnd) {
       // handle tempo loop sync for loop end
       if (this.#loopTempoSync) {
@@ -993,20 +988,18 @@ export class SamplePlayer implements ILibInstrumentNode {
         loopEnd = loopStart + numBeats * beatDuration;
       }
 
-      const storeLoopEnd = () => this.storeParamValue('loopEnd', loopEnd);
-
       if (targetLoopDuration < this.MIN_LOOP_DURATION_SECONDS) {
         loopEnd = loopStart + this.MIN_LOOP_DURATION_SECONDS;
       }
 
-      this.#macroLoopEnd.ramp(loopEnd, scaledRampTime, loopStart, {
-        onComplete: () => {
-          storeLoopEnd();
-        },
-      });
+      this.#macroLoopEnd.ramp(loopEnd, scaledRampTime, loopStart);
+      this.storeParamValue('loopEnd', this.loopEnd);
     }
 
-    this.sendUpstreamMessage('loop-points:updated', { loopStart, loopEnd });
+    this.sendUpstreamMessage('loop-points:updated', {
+      loopStart: this.loopStart,
+      loopEnd: this.loopEnd,
+    });
 
     return this;
   }
@@ -1401,11 +1394,11 @@ export class SamplePlayer implements ILibInstrumentNode {
   }
 
   get loopStart(): number {
-    return this.#macroLoopStart.getValue();
+    return this.#macroLoopStart.targetValue;
   }
 
   get loopEnd(): number {
-    return this.#macroLoopEnd.getValue();
+    return this.#macroLoopEnd.targetValue;
   }
 
   get isLoaded() {

--- a/packages/audiolib/src/nodes/params/macros/MacroParam.ts
+++ b/packages/audiolib/src/nodes/params/macros/MacroParam.ts
@@ -22,6 +22,7 @@ export class MacroParam {
   #messages: MessageBus<Message>;
   #paramType: string = '';
   #isReady: boolean = false;
+  #currentTargetValue: number;
 
   constructor(context: BaseAudioContext, initialValue: number) {
     this.#controller = new AudioParamController(context, initialValue);
@@ -30,6 +31,7 @@ export class MacroParam {
 
     this.#messages = createMessageBus(this.#controller.nodeId);
     this.nodeId = this.#controller.nodeId;
+    this.#currentTargetValue = initialValue;
 
     this.#isReady = true;
   }
@@ -54,8 +56,6 @@ export class MacroParam {
     return this;
   }
 
-  #currentTargetValue = 0;
-
   ramp(
     targetValue: number,
     duration: number,
@@ -67,13 +67,14 @@ export class MacroParam {
       onCompleteDelayMs?: number;
     } = {},
   ): this {
-    if (targetValue === this.#currentTargetValue) return this;
+    const processedValue = this.#processValue(targetValue, constant);
+    if (processedValue === this.#currentTargetValue) return this;
 
     // const direction =
-    //   targetValue > this.#currentTargetValue ? 'increment' : 'decrement';
+    //   processedValue > this.#currentTargetValue ? 'increment' : 'decrement';
     // console.debug(this.#paramType, direction);
 
-    this.#currentTargetValue = targetValue;
+    this.#currentTargetValue = processedValue;
 
     const {
       method = 'exponential',
@@ -83,8 +84,6 @@ export class MacroParam {
     } = options;
 
     const executeRamp = () => {
-      let processedValue = this.#processValue(targetValue, constant);
-
       this.#controller.ramp(processedValue, duration, method, true);
 
       if (onComplete) {
@@ -232,6 +231,10 @@ export class MacroParam {
   }
 
   getValue = (): number => this.#controller.value;
+
+  get targetValue(): number {
+    return this.#currentTargetValue;
+  }
 
   get targets() {
     return this.#controller.targets;

--- a/packages/audiolib/src/nodes/params/macros/MacroParam.ts
+++ b/packages/audiolib/src/nodes/params/macros/MacroParam.ts
@@ -6,7 +6,8 @@ import {
 } from '@/events';
 import { ROOT_NOTES, SCALE_PATTERNS } from '@/utils/music-theory/constants';
 import { Debouncer } from '@/utils/Debouncer';
-import { AudioParamController, ValueSnapper } from '@/nodes/params';
+import { AudioParamController } from './AudioParamController';
+import { ValueSnapper } from '../helpers/ValueSnapper';
 import { assert } from '@/utils';
 import { NodeType } from '@/nodes/LibNode';
 import type { NormalizeOptions } from '@/nodes/params/param-types';
@@ -40,13 +41,13 @@ export class MacroParam {
   addTarget(
     targetParam: AudioParam,
     paramType: string,
-    scaleFactor: number = 1
+    scaleFactor: number = 1,
   ): this {
     if (!this.#paramType) this.#paramType = paramType;
     assert(
       // todo: allow multiple types
       paramType === this.#paramType,
-      'Macros only support a single ParamType'
+      'Macros only support a single ParamType',
     );
 
     this.#controller.addTarget(targetParam, scaleFactor);
@@ -64,7 +65,7 @@ export class MacroParam {
       debounceMs?: number;
       onComplete?: () => void;
       onCompleteDelayMs?: number;
-    } = {}
+    } = {},
   ): this {
     if (targetValue === this.#currentTargetValue) return this;
 
@@ -97,7 +98,7 @@ export class MacroParam {
       const debounced = this.#debouncer.debounce(
         executeRamp,
         debounceMs,
-        this.nodeId // explicit key (can be omitted for auto-keying)
+        this.nodeId, // explicit key (can be omitted for auto-keying)
       );
       debounced();
     }
@@ -176,7 +177,7 @@ export class MacroParam {
   // Delegate configuration methods
   setAllowedParamValues(
     values: number[],
-    normalize: NormalizeOptions | false
+    normalize: NormalizeOptions | false,
   ): number[] {
     return this.#snapper.setAllowedValues(values, normalize);
   }
@@ -184,12 +185,12 @@ export class MacroParam {
   setAllowedPeriods(
     periods: number[],
     normalize: NormalizeOptions | false,
-    snapToZeroCrossings: number[] | false = false
+    snapToZeroCrossings: number[] | false = false,
   ): number[] {
     return this.#snapper.setAllowedPeriods(
       periods,
       normalize,
-      snapToZeroCrossings
+      snapToZeroCrossings,
     );
   }
 
@@ -219,7 +220,7 @@ export class MacroParam {
       lowestOctave,
       highestOctave,
       options.normalize,
-      options.snapToZeroCrossings
+      options.snapToZeroCrossings,
     );
   }
 
@@ -299,7 +300,7 @@ export class MacroParam {
     constant: number,
     targetPeriod: number,
     quantizedPeriod: number,
-    result: number
+    result: number,
   ) => {
     console.debug(
       'adjusting param: ',
@@ -313,7 +314,7 @@ export class MacroParam {
       'quantizedPeriod',
       quantizedPeriod,
       'result',
-      result
+      result,
     );
   };
 


### PR DESCRIPTION
## Summary

- preserve the unchanged loop boundary when callers move the other point past it
- make processed MacroParam targets immediately available as the authoritative loop values
- persist and publish accepted loop targets instead of delayed or unsnapped values
- expose generic dynamic knob limits and use them for Play's loop start/end controls
- replace the Play loop-duration control with an explicit loop-end control

## Why

Setting loop end at or before loop start could adjust only a local copy of loop start, leaving the actual macro parameters inverted. Macro getters also lagged behind debounced ramps, which made rapid updates and UI synchronization depend on stale values. In Play, the knob readout could remain correct while the knob visual moved past the opposite boundary.

## Impact

SamplePlayer now keeps loop point targets ordered and exposes accepted processed targets synchronously. The Play demo blocks loop point drags at the opposite control while retaining a shared visual scale. The current normalized gap calculation is intentionally scoped to the demo and remains marked for a cleaner reusable audiolib parameter pattern.

## Validation

- `pnpm --filter @repo/audiolib test` — 116 passed, 1 skipped
- `pnpm exec tsc -p apps/play/tsconfig.json --noEmit`
- `git diff --check origin/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added independent loop start and loop end controls for sample playback.
  - Loop controls now automatically enforce the minimum valid spacing based on sample and playback settings.

- **Bug Fixes**
  - Improved loop-point updates while playback parameters are changing.
  - Corrected loop position resets when loading a new sample.
  - Ensured knob values remain within valid ranges and reset correctly when adjusted values are constrained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->