### PR TITLE
Remove legacy target node routing from Play

### DIFF
--- a/apps/play/src/App.tsx
+++ b/apps/play/src/App.tsx
@@ -131,7 +131,6 @@ const App: Component = () => {
       document.dispatchEvent(
         new CustomEvent('sample-loaded', {
           detail: {
-            nodeId: 'test-sampler',
             buffer: audiobuffer,
             durationSeconds: audiobuffer.duration,
           },
@@ -160,9 +159,7 @@ const App: Component = () => {
 
         // Temporary readiness signal for the remaining vanilla controls.
         document.dispatchEvent(
-          new CustomEvent('sampler-initialized', {
-            detail: { nodeId: 'test-sampler' },
-          }),
+          new CustomEvent('sampler-initialized'),
         );
 
         // createSamplePlayer resolves after its initial sample has loaded.
@@ -174,7 +171,6 @@ const App: Component = () => {
         document.dispatchEvent(
           new CustomEvent('sampler-error', {
             detail: {
-              nodeId: 'test-sampler',
               error: errText,
               ...(errText.includes('AudioWorklet') && {
                 error: 'AudioWorklet not supported',

--- a/apps/play/src/App.tsx
+++ b/apps/play/src/App.tsx
@@ -390,7 +390,6 @@ const App: Component = () => {
             </div>
 
             {/* <tempo-knob
-          target-node-id='test-sampler'
           label=' '
           class={`left-side-button ${sidebarOpen() ? 'open' : ''} `}
         /> */}
@@ -429,7 +428,6 @@ const App: Component = () => {
                 <envelope-switcher
                   height={envHeight()}
                   bg-color='var(--envelope-bg)'
-                  target-node-id='test-sampler'
                 />
               </div>
             </div>
@@ -441,12 +439,10 @@ const App: Component = () => {
               <ParamKnob param='volume' player={samplePlayer()} />
               <div class='flex-col'>
                 <record-button
-                  target-node-id='test-sampler'
                   show-status='false'
                 />
                 <div class='input-source-selection-container'>
                   <input-select
-                    target-node-id='test-sampler'
                     class='input-source-select'
                   />
                   <InputDeviceSelect
@@ -459,7 +455,6 @@ const App: Component = () => {
               </div>
               <div class='flex-col'>
                 <load-button
-                  target-node-id='test-sampler'
                   show-status='false'
                 />
 
@@ -537,7 +532,6 @@ const App: Component = () => {
               >
                 <ParamKnob param='amMod' label='AM' player={samplePlayer()} />
                 <waveform-select
-                  target-node-id='test-sampler'
                   show-label='false'
                 />
               </div>
@@ -684,34 +678,31 @@ const App: Component = () => {
                 player={samplePlayer()}
                 class='sampler-toggle-container'
               />
-              {/* <midi-toggle target-node-id='test-sampler' /> */}
-              <playback-direction-toggle target-node-id='test-sampler' />
-              <loop-lock-toggle target-node-id='test-sampler' />
-              <hold-lock-toggle target-node-id='test-sampler' />
-              <pitch-toggle target-node-id='test-sampler' />
-              <sampler-status target-node-id='test-sampler' />
+              {/* <midi-toggle /> */}
+              <playback-direction-toggle />
+              <loop-lock-toggle />
+              <hold-lock-toggle />
+              <pitch-toggle />
+              <sampler-status />
             </div>
           </fieldset>
 
           <fieldset class='control-group keyboard-group'>
             <legend class='expandable-legend'>Keyboard</legend>
-            <computer-keyboard target-node-id='test-sampler' />
+            <computer-keyboard />
             <div class='expandable-content'>
               <piano-keyboard
                 id='piano-keyboard'
                 class='piano-keyboard'
-                target-node-id='test-sampler'
                 height='80'
               />
               <div class='keyboard-controls'>
                 <div class='flex-row'>
                   <rootnote-select
                     show-label='false'
-                    target-node-id='test-sampler'
                   />
                   <keymap-select
                     show-label='false'
-                    target-node-id='test-sampler'
                   />
                 </div>
 

--- a/apps/play/src/audio-elements/elements/Sampler/components/ComputerKeyboard.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/ComputerKeyboard.ts
@@ -1,5 +1,5 @@
 // ComputerKeyboard.ts
-import van, { State } from '@repo/vanjs-core';
+import van from '@repo/vanjs-core';
 import { ElementProps } from '@repo/vanjs-core/element';
 import {
   keyboardEnabledInstruments,
@@ -19,7 +19,6 @@ import {
 const { div } = van.tags;
 
 export const ComputerKeyboard = (attributes: ElementProps) => {
-  const targetNodeId: State<string> = attributes.attr('target-node-id', '');
   const enabled = van.state(true);
   const currentKeymap = van.state(KeyMaps[DEFAULT_KEYMAP_KEY]);
   const octaveOffset = van.state(0);
@@ -34,9 +33,7 @@ export const ComputerKeyboard = (attributes: ElementProps) => {
 
   // Listen for keymap changes from the select component
   const handleKeymapChange = (e: CustomEvent) => {
-    if (e.detail.targetNodeId === targetNodeId.val) {
-      currentKeymap.val = e.detail.keymap;
-    }
+    currentKeymap.val = e.detail.keymap;
   };
 
   const handleOctaveChange = (direction: number) => {

--- a/apps/play/src/audio-elements/elements/Sampler/components/PianoKeyboard.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/PianoKeyboard.ts
@@ -1,4 +1,4 @@
-import van, { State } from '@repo/vanjs-core';
+import van from '@repo/vanjs-core';
 import { ElementProps } from '@repo/vanjs-core/element';
 import '../../controls/webaudio-controls/webaudio-keyboard';
 import { getSamplePlayer } from '../../../../App';
@@ -16,7 +16,6 @@ const MOBILE_KEY_COUNT = 13;
 const MOBILE_MIN_NOTE = 48; // C3
 
 export const PianoKeyboard = (attributes: ElementProps) => {
-  const targetNodeId: State<string> = attributes.attr('target-node-id', '');
   const width = attributes.attr('width', '300');
   const height = attributes.attr('height', '60');
   const enabled = van.state(true);
@@ -111,29 +110,19 @@ export const PianoKeyboard = (attributes: ElementProps) => {
 
     // Sync octave changes from ComputerKeyboard
     const handleKeymapChange = (e: CustomEvent) => {
-      if (
-        e.detail.targetNodeId === targetNodeId.val ||
-        !e.detail.targetNodeId
-      ) {
-        // Sync keymap and octave offset
-        if (e.detail.keymap) {
-          currentKeymap.val = e.detail.keymap;
-        }
-        if (e.detail.octaveOffset !== undefined) {
-          octaveOffset.val = e.detail.octaveOffset;
-        }
+      // Sync keymap and octave offset
+      if (e.detail.keymap) {
+        currentKeymap.val = e.detail.keymap;
+      }
+      if (e.detail.octaveOffset !== undefined) {
+        octaveOffset.val = e.detail.octaveOffset;
       }
     };
 
     // Listen for root note changes
     const handleRootNoteChange = (e: CustomEvent) => {
-      if (
-        e.detail.targetNodeId === targetNodeId.val ||
-        !e.detail.targetNodeId
-      ) {
-        if (e.detail.rootNote) {
-          rootNote.val = e.detail.rootNote;
-        }
+      if (e.detail.rootNote) {
+        rootNote.val = e.detail.rootNote;
       }
     };
 

--- a/apps/play/src/audio-elements/elements/Sampler/components/SamplerSelectFactory.ts
+++ b/apps/play/src/audio-elements/elements/Sampler/components/SamplerSelectFactory.ts
@@ -38,7 +38,6 @@ export interface SelectConfig<T extends string = string> {
     target: any,
     state: State<T>,
     van: any,
-    targetNodeId: string,
   ) => void;
 }
 
@@ -59,7 +58,6 @@ const keymapSelectConfig: SelectConfig<keyof typeof KeyMaps> = {
     sampler: any,
     state: State<keyof typeof KeyMaps>,
     van: any,
-    targetNodeId: string,
   ) => {
     van.derive(() => {
       const selectedKeymap = state.val;
@@ -71,7 +69,6 @@ const keymapSelectConfig: SelectConfig<keyof typeof KeyMaps> = {
           detail: {
             keymap,
             selectedValue: state.val,
-            targetNodeId: targetNodeId,
           },
         }),
       );
@@ -115,7 +112,6 @@ const waveformSelectConfig: SelectConfig<SupportedWaveform> = {
     sampler: any,
     state: State<SupportedWaveform>,
     van: any,
-    targetNodeId: string,
   ) => {
     // Set up reactive binding to sampler method
     van.derive(() => {
@@ -152,7 +148,6 @@ const rootNoteSelectConfig: SelectConfig<RootNote> = {
     sampler: any,
     state: State<RootNote>,
     van: any,
-    targetNodeId: string,
   ) => {
     van.derive(() => {
       const safeRoot = ROOT_NOTES.includes(state.val)
@@ -164,7 +159,6 @@ const rootNoteSelectConfig: SelectConfig<RootNote> = {
         new CustomEvent('rootnote-changed', {
           detail: {
             rootNote: safeRoot,
-            targetNodeId: targetNodeId,
           },
         }),
       );
@@ -195,7 +189,6 @@ const inputSourceSelectConfig: SelectConfig<
     sampler: any,
     state: State<'audio-input' | 'browser' | 'resample'>,
     van: any,
-    targetNodeId: string,
   ) => {
     van.derive(() => {
       setRecorderInputSource(state.val);
@@ -221,7 +214,7 @@ const createSamplerSelect = <T extends string = string>(
       (sampler: SamplePlayer) => {
         if (config.onTargetConnect) {
           try {
-            config.onTargetConnect(sampler, state, van, sampler.nodeId);
+            config.onTargetConnect(sampler, state, van);
           } catch (error) {
             console.error(
               `Failed to connect select "${config.label || 'unnamed'}":`,


### PR DESCRIPTION
## What changed

- remove obsolete `target-node-id` attributes from the Play app
- remove node-ID filtering from the legacy computer and piano keyboards
- simplify select callbacks and keyboard synchronization events by dropping the unused target ID

## Why

Play owns a single `SamplePlayer`, so target-node routing no longer selects between sampler instances. The remaining filters compared the hard-coded `test-sampler` attribute with audiolib's generated node ID, causing keymap and root-note synchronization events to be rejected.

## Impact

Keymap changes now reach both keyboard controls, and root-note changes update the piano visualization. This intentionally adopts Play's existing single-player model; it does not change the reusable `packages/audio-components` API.

## Validation

- `pnpm build` in `apps/play`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sampler keyboard, piano, and control synchronization by removing outdated target-specific filtering.
  * Ensured keymap, octave, and root-note updates apply consistently to the active sampler.
  * Simplified sampler control connections for more reliable interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->