### PR TITLE
Clarify tryCatch callback contract

### DIFF
--- a/packages/audiolib/src/utils/code/tryCatch.md
+++ b/packages/audiolib/src/utils/code/tryCatch.md
@@ -1,5 +1,7 @@
 ## Usage Example: `tryCatch`
 
+`fn` may return a value, `void`, or a `Promise`. On success, the returned or resolved value is stored in `data`.
+
 ### For Synchronous Functions
 
 ```typescript

--- a/packages/audiolib/src/utils/code/tryCatch.ts
+++ b/packages/audiolib/src/utils/code/tryCatch.ts
@@ -11,10 +11,12 @@ function isPromiseLike<T>(value: any): value is PromiseLike<T> {
 }
 
 /**
- * Handles error handling for functions that may return sync or async values.
+ * Runs a sync or async function and returns `{ data, error }`.
+ * On success, the function's return value or resolved value is stored in `data`.
+ * If the function only performs side effects, it may return `void`.
  * Always returns a Promise and must be awaited.
  *
- * @param fn A function that returns a value or a Promise
+ * @param fn Function to execute. May return a value, `void`, or a Promise.
  * @param errorMessage Optional custom error message
  * @param logError Whether to log the error to console (defaults to true)
  * @returns A Promise resolving to a Result object


### PR DESCRIPTION
- Clarify that tryCatch preserves sync or async return values in result.data\n- State that callbacks may return void for side-effect-only use\n- Keep the markdown example section minimal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `tryCatch` supports synchronous values, `void` returns, and promises.
  * Documented that successful returned or resolved values are stored in `data`, while failures are reported through `error`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->